### PR TITLE
Braille pane preserve untouched cells

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,4 @@
 # Working in this repo
 
+- When fixing a bug, find the root cause rather than patching the symptom — check whether the same assumption or logic is duplicated elsewhere (e.g. a CI workflow with its own hard-coded dependency list, a parallel implementation in another file/language) before considering a fix complete.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brailletools/braille2latex",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Braille to LaTeX converter supporting Nemeth math notation",
   "type": "module",
   "exports": {

--- a/src/document.js
+++ b/src/document.js
@@ -366,45 +366,63 @@ export class DualDocument {
 			if (node.token === tokens.EQUATION) {
 				const mathBody = extractMathBody(latexSlice);
 				newBrailleForNode = '_%' + latex_to_nemeth(mathBody) + '_:';
-			} else if (node.childRangesReliable === true) {
-				// Only forward-translate the actually-changed sub-range and splice it
-				// into the node's existing (untouched) braille, instead of regenerating
-				// the whole paragraph — see braille2latex#19. node.latex and latexSlice
-				// are both node-relative (0-based at this node's own latex start), same
-				// coordinate space assignParaChildBrailleRanges() stamped children's
+			} else {
+				// node.latex and latexSlice are both node-relative (0-based at this
+				// node's own latex start), same coordinate space
+				// assignParaChildBrailleRanges() stamped children's
 				// latexRange/brailleRange in, so this diff needs no extra offset math
 				// beyond what the document-level diff above already did.
-				const forward = this._translateForward || defaultTranslateForward;
+				const children = node.children;
 				const { prefixLen: childPrefixLen, suffixLen: childSuffixLen } = diffRegion(node.latex, latexSlice);
 				const oldChildRegionStart = childPrefixLen;
 				const oldChildRegionEnd = node.latex.length - childSuffixLen;
 
-				const children = node.children;
-				const childFirstIdx = findOwningIndex(children, 'latexRange', oldChildRegionStart);
-				const childLastIdx =
-					oldChildRegionEnd > oldChildRegionStart
-						? findOwningIndex(children, 'latexRange', oldChildRegionEnd - 1)
-						: childFirstIdx;
+				// children only cover their own span text, not PARA-level glue outside
+				// it (e.g. the trailing "\n\n" to_latex() appends, or display-math
+				// spacing) -- unlike top-level nodes, whose ranges are extended by
+				// findOwningIndex's "gap belongs to preceding node" convention. Splicing
+				// is only safe when the edited region is actually inside the span the
+				// children cover; otherwise findOwningIndex would silently clamp an
+				// out-of-range offset onto the nearest child and corrupt it.
+				const canSplice =
+					node.childRangesReliable === true &&
+					children.length > 0 &&
+					oldChildRegionStart >= children[0].latexRange.start &&
+					oldChildRegionEnd <= children[children.length - 1].latexRange.end;
 
-				const childRegionStart = children[childFirstIdx].latexRange.start;
-				const childRegionNewEnd = children[childLastIdx].latexRange.end + delta;
-				const newChildRegionLatex = latexSlice.slice(childRegionStart, childRegionNewEnd);
+				if (canSplice) {
+					// Only forward-translate the actually-changed sub-range and splice it
+					// into the node's existing (untouched) braille, instead of regenerating
+					// the whole paragraph — see braille2latex#19.
+					const forward = this._translateForward || defaultTranslateForward;
+					const childFirstIdx = findOwningIndex(children, 'latexRange', oldChildRegionStart);
+					const childLastIdx =
+						oldChildRegionEnd > oldChildRegionStart
+							? findOwningIndex(children, 'latexRange', oldChildRegionEnd - 1)
+							: childFirstIdx;
 
-				const newBrailleForChildRegion = await regenerateParaBraille(newChildRegionLatex, this.table, forward);
+					const childRegionStart = children[childFirstIdx].latexRange.start;
+					const childRegionNewEnd = children[childLastIdx].latexRange.end + delta;
+					const newChildRegionLatex = latexSlice.slice(childRegionStart, childRegionNewEnd);
 
-				const oldNodeBrailleText = this.brailleText.slice(node.brailleRange.start, node.brailleRange.end);
-				const childBrailleStart = children[childFirstIdx].brailleRange.start;
-				const childBrailleOldEnd = children[childLastIdx].brailleRange.end;
-				newBrailleForNode =
-					oldNodeBrailleText.slice(0, childBrailleStart) +
-					newBrailleForChildRegion +
-					oldNodeBrailleText.slice(childBrailleOldEnd);
-			} else {
-				// No reliable child ranges for this node (e.g. a lexer edge case the
-				// marker-only scan in processFile.js doesn't cover) — fall back to
-				// regenerating the whole node, same as before braille2latex#19's fix.
-				const forward = this._translateForward || defaultTranslateForward;
-				newBrailleForNode = await regenerateParaBraille(latexSlice, this.table, forward);
+					const newBrailleForChildRegion = await regenerateParaBraille(newChildRegionLatex, this.table, forward);
+
+					const oldNodeBrailleText = this.brailleText.slice(node.brailleRange.start, node.brailleRange.end);
+					const childBrailleStart = children[childFirstIdx].brailleRange.start;
+					const childBrailleOldEnd = children[childLastIdx].brailleRange.end;
+					newBrailleForNode =
+						oldNodeBrailleText.slice(0, childBrailleStart) +
+						newBrailleForChildRegion +
+						oldNodeBrailleText.slice(childBrailleOldEnd);
+				} else {
+					// No reliable child ranges for this node (e.g. a lexer edge case the
+					// marker-only scan in processFile.js doesn't cover), no children at
+					// all (empty paragraph), or the edited region falls outside every
+					// child's actual latex coverage -- fall back to regenerating the
+					// whole node, same as before braille2latex#19's fix.
+					const forward = this._translateForward || defaultTranslateForward;
+					newBrailleForNode = await regenerateParaBraille(latexSlice, this.table, forward);
+				}
 			}
 		} catch (error) {
 			node.status = 'error';

--- a/src/document.js
+++ b/src/document.js
@@ -104,6 +104,37 @@ function segmentMixedLatex(latexSlice) {
 	return segments;
 }
 
+// Forward-translates a PARA node's latex text (or, from applyLatexEdit's partial-
+// update path, just a touched sub-range of one) into braille-ASCII — segments
+// prose vs inline/display math (see segmentMixedLatex's doc comment above) and
+// translates each through the right pipeline. Shared by both the whole-node
+// fallback path and the partial/child-region path below, so they build a
+// replacement string the same way.
+async function regenerateParaBraille(latexText, table, forward) {
+	const parts = [];
+	for (const segment of segmentMixedLatex(latexText)) {
+		if (segment.type === 'math') {
+			parts.push('_%' + latex_to_nemeth(segment.text) + '_:');
+		} else {
+			const prose = stripProseMarkup(segment.text);
+			if (prose === '') continue;
+			// liblouis's translateString(..., backtranslate=false) returns
+			// braille-ASCII text directly (e.g. "c " for "can", the grade-2
+			// contraction) — NOT Unicode braille glyphs, despite the parallel
+			// with defaultLiblouisTranslate's back-translate direction (which
+			// takes Unicode braille IN). Running this back through
+			// braille2Ascii() a second time fed it non-Unicode-braille input
+			// and hit the same "undefined" sentinel bug from a different
+			// angle. Use the result as-is; it's already in the ASCII-braille
+			// form node.value expects (case doesn't affect which cell a basic
+			// letter maps to, so liblouis's lowercase output round-trips fine
+			// through ascii2Braille() later).
+			parts.push(await forward(prose, table));
+		}
+	}
+	return parts.join('');
+}
+
 export class DualDocument {
 	constructor({ tree, table, translate, translateForward }) {
 		this._tree = tree;
@@ -335,34 +366,45 @@ export class DualDocument {
 			if (node.token === tokens.EQUATION) {
 				const mathBody = extractMathBody(latexSlice);
 				newBrailleForNode = '_%' + latex_to_nemeth(mathBody) + '_:';
-			} else {
-				// PARA nodes can mix prose and math as siblings (see
-				// segmentMixedLatex's doc comment) — translate each segment through
-				// the right pipeline and concatenate, rather than treating the whole
-				// slice as prose.
+			} else if (node.childRangesReliable === true) {
+				// Only forward-translate the actually-changed sub-range and splice it
+				// into the node's existing (untouched) braille, instead of regenerating
+				// the whole paragraph — see braille2latex#19. node.latex and latexSlice
+				// are both node-relative (0-based at this node's own latex start), same
+				// coordinate space assignParaChildBrailleRanges() stamped children's
+				// latexRange/brailleRange in, so this diff needs no extra offset math
+				// beyond what the document-level diff above already did.
 				const forward = this._translateForward || defaultTranslateForward;
-				const parts = [];
-				for (const segment of segmentMixedLatex(latexSlice)) {
-					if (segment.type === 'math') {
-						parts.push('_%' + latex_to_nemeth(segment.text) + '_:');
-					} else {
-						const prose = stripProseMarkup(segment.text);
-						if (prose === '') continue;
-						// liblouis's translateString(..., backtranslate=false) returns
-						// braille-ASCII text directly (e.g. "c " for "can", the grade-2
-						// contraction) — NOT Unicode braille glyphs, despite the parallel
-						// with defaultLiblouisTranslate's back-translate direction (which
-						// takes Unicode braille IN). Running this back through
-						// braille2Ascii() a second time fed it non-Unicode-braille input
-						// and hit the same "undefined" sentinel bug from a different
-						// angle. Use the result as-is; it's already in the ASCII-braille
-						// form node.value expects (case doesn't affect which cell a basic
-						// letter maps to, so liblouis's lowercase output round-trips fine
-						// through ascii2Braille() later).
-						parts.push(await forward(prose, this.table));
-					}
-				}
-				newBrailleForNode = parts.join('');
+				const { prefixLen: childPrefixLen, suffixLen: childSuffixLen } = diffRegion(node.latex, latexSlice);
+				const oldChildRegionStart = childPrefixLen;
+				const oldChildRegionEnd = node.latex.length - childSuffixLen;
+
+				const children = node.children;
+				const childFirstIdx = findOwningIndex(children, 'latexRange', oldChildRegionStart);
+				const childLastIdx =
+					oldChildRegionEnd > oldChildRegionStart
+						? findOwningIndex(children, 'latexRange', oldChildRegionEnd - 1)
+						: childFirstIdx;
+
+				const childRegionStart = children[childFirstIdx].latexRange.start;
+				const childRegionNewEnd = children[childLastIdx].latexRange.end + delta;
+				const newChildRegionLatex = latexSlice.slice(childRegionStart, childRegionNewEnd);
+
+				const newBrailleForChildRegion = await regenerateParaBraille(newChildRegionLatex, this.table, forward);
+
+				const oldNodeBrailleText = this.brailleText.slice(node.brailleRange.start, node.brailleRange.end);
+				const childBrailleStart = children[childFirstIdx].brailleRange.start;
+				const childBrailleOldEnd = children[childLastIdx].brailleRange.end;
+				newBrailleForNode =
+					oldNodeBrailleText.slice(0, childBrailleStart) +
+					newBrailleForChildRegion +
+					oldNodeBrailleText.slice(childBrailleOldEnd);
+			} else {
+				// No reliable child ranges for this node (e.g. a lexer edge case the
+				// marker-only scan in processFile.js doesn't cover) — fall back to
+				// regenerating the whole node, same as before braille2latex#19's fix.
+				const forward = this._translateForward || defaultTranslateForward;
+				newBrailleForNode = await regenerateParaBraille(latexSlice, this.table, forward);
 			}
 		} catch (error) {
 			node.status = 'error';

--- a/src/processFile.js
+++ b/src/processFile.js
@@ -669,9 +669,22 @@ export function lex(text) {
 				}
 			}
 			
-			// Add newline after each line within NEMETH blocks (but not after last line)
-			if (lineIndex < lines.length - 1 && currentToken.token === tokens.NEMETH) {
-				currentToken.add_character('\n');
+			// A single '\n' inside a paragraph is a line wrap, not a paragraph break
+			// (that's '\n\n', split out above) -- it still stands for whitespace between
+			// the last word of this line and the first word of the next, or the last
+			// word of one line and the last word of the next line fuse together with
+			// no separator at all. NEMETH content preserves the literal newline instead
+			// (verbatim rendering of Nemeth math); everything else gets a space.
+			if (lineIndex < lines.length - 1) {
+				if (currentToken.token === tokens.NEMETH) {
+					currentToken.add_character('\n');
+				} else if (
+					currentToken.token === tokens.STRING ||
+					currentToken.token === tokens.BOLD ||
+					currentToken.token === tokens.ITALIC
+				) {
+					currentToken.add_character(' ');
+				}
 			}
 		});
 

--- a/src/processFile.js
+++ b/src/processFile.js
@@ -536,6 +536,7 @@ function assignParaChildBrailleRanges(paraNode, paraRawText) {
 	const children = paraNode.children;
 
 	const matches =
+		children.length > 0 &&
 		spans.length === children.length &&
 		spans.every((span, i) => TOKEN_FOR_SPAN_TYPE[span.type] === children[i].token);
 

--- a/src/processFile.js
+++ b/src/processFile.js
@@ -198,6 +198,12 @@ class Element {
 		// the ROOT case of to_latex().
 		this.brailleRange = null;
 		this.latexRange = null;
+		// PARA nodes only: true once assignParaChildBrailleRanges() has verified its
+		// marker-only boundary scan exactly matches this node's real children (count
+		// + token-type-in-order), meaning every child's brailleRange above is safe to
+		// use for splicing. Left undefined (falsy) otherwise -- applyLatexEdit treats
+		// that as "fall back to regenerating the whole node," never guesses.
+		this.childRangesReliable = undefined;
 		this.reset_latex();
 	}
 
@@ -299,7 +305,12 @@ class Element {
 							// Ensure display math starts on its own line when it follows text
 							this.add_latex('\n\n');
 						}
+						// Node-relative (0-based at this PARA's own latex start), mirroring
+						// the ROOT case above one level down — see applyLatexEdit's use of
+						// this for splicing only the touched child(ren)'s braille.
+						const startLen = this.latex.length;
 						this.add_latex(childLatex);
+						child.latexRange = { start: startLen, end: startLen + childLatex.length };
 					} catch (error) {
 						console.error('[processFile] Error processing PARA child:', error.message, 'token:', child.token);
 						// Continue processing remaining children
@@ -419,6 +430,126 @@ function assignTopLevelBrailleRanges(root, normalizedText) {
 	});
 }
 
+// Maps each of the four structural markers lex() recognizes to the span type it
+// opens — 'nemeth'/'bold'/'italic' spans nest (a NEMETH, BOLD, or ITALIC region
+// can contain any of the others); plain content between/outside them is 'text'.
+const SPAN_TYPE_FOR_MARKER = {
+	[tokenStrings[tokens.BOLD]]: 'bold',
+	[tokenStrings[tokens.ITALIC]]: 'italic'
+};
+
+// A lightweight, marker-only scan of one paragraph's raw braille text, computing
+// the top-level (direct-PARA-child) span boundaries a correctly-formed input
+// would produce, WITHOUT re-running lex()'s word-splitting/character-loop logic.
+// Returns an ordered, gapless, non-overlapping partition of [0, rawParaText.length):
+// [{ type: 'text'|'nemeth'|'bold'|'italic', start, end }, ...].
+//
+// This mirrors lex()'s marker push/pop rules (verified by hand against the word-
+// and character-based branches there) closely enough to get well-formed input
+// right, but it is deliberately NOT a full reimplementation of the lexer (e.g. it
+// doesn't replicate every pre-existing lexer quirk around markers landing mid-word
+// with no surrounding space). That's fine: assignParaChildBrailleRanges() below
+// cross-checks this scan's output against the real parse tree and discards it on
+// any mismatch, so a wrong guess here only costs the fast path for that one
+// paragraph — see braille2latex#19.
+function computeTopLevelBrailleSpans(rawParaText) {
+	const spans = [];
+	const stack = []; // entries: 'nemeth' | 'bold' | 'italic', innermost last
+	let spanStart = 0;
+	let spanType = null; // null until the first character of the current span decides it
+
+	const closeSpanIfOpen = (end) => {
+		if (spanType !== null && end > spanStart) {
+			spans.push({ type: spanType, start: spanStart, end });
+		}
+		spanType = null;
+	};
+
+	let i = 0;
+	while (i < rawParaText.length) {
+		const two = rawParaText.substring(i, i + 2);
+
+		if (two === tokenStrings[tokens.NEMETHSTART]) {
+			if (stack.length === 0) {
+				closeSpanIfOpen(i);
+				spanStart = i;
+				spanType = 'nemeth';
+			}
+			stack.push('nemeth'); // always pushes, even nested inside another NEMETH
+			i += 2;
+			continue;
+		}
+
+		if (two === tokenStrings[tokens.NEMETHSTOP]) {
+			if (stack[stack.length - 1] === 'nemeth') stack.pop(); // else: stray marker, no-op
+			i += 2;
+			if (stack.length === 0) closeSpanIfOpen(i);
+			continue;
+		}
+
+		const markerType = SPAN_TYPE_FOR_MARKER[two];
+		if (markerType) {
+			if (stack.length === 0) {
+				closeSpanIfOpen(i);
+				spanStart = i;
+				spanType = markerType;
+			}
+			// Toggle relative to the *immediate* top of stack only, matching lex()'s
+			// `currentToken.token === BOLD ? parent : push(BOLD)` (not a deep search).
+			if (stack[stack.length - 1] === markerType) {
+				stack.pop();
+			} else {
+				stack.push(markerType);
+			}
+			i += 2;
+			if (stack.length === 0) closeSpanIfOpen(i);
+			continue;
+		}
+
+		// Plain character — starts a new top-level 'text' span if one isn't already open.
+		if (stack.length === 0 && spanType === null) {
+			spanStart = i;
+			spanType = 'text';
+		}
+		i += 1;
+	}
+	closeSpanIfOpen(rawParaText.length);
+
+	return spans;
+}
+
+const TOKEN_FOR_SPAN_TYPE = {
+	text: tokens.STRING,
+	nemeth: tokens.NEMETH,
+	bold: tokens.BOLD,
+	italic: tokens.ITALIC
+};
+
+// Runs computeTopLevelBrailleSpans() and cross-checks it against paraNode's real
+// children (count + token-type-in-order) before trusting it for anything. On a
+// match, stamps each child's brailleRange from the scan and marks the node
+// childRangesReliable; on any mismatch, leaves children's brailleRange untouched
+// (null) and childRangesReliable false, so applyLatexEdit's PARA branch falls back
+// to regenerating the whole node rather than guessing at a wrong splice point.
+function assignParaChildBrailleRanges(paraNode, paraRawText) {
+	const spans = computeTopLevelBrailleSpans(paraRawText);
+	const children = paraNode.children;
+
+	const matches =
+		spans.length === children.length &&
+		spans.every((span, i) => TOKEN_FOR_SPAN_TYPE[span.type] === children[i].token);
+
+	if (!matches) {
+		paraNode.childRangesReliable = false;
+		return;
+	}
+
+	spans.forEach((span, i) => {
+		children[i].brailleRange = { start: span.start, end: span.end };
+	});
+	paraNode.childRangesReliable = true;
+}
+
 export function lex(text) {
 	if (typeof text !== 'string') throw new Error('Input must be a string');
 
@@ -466,23 +597,6 @@ export function lex(text) {
 				const words = line.split(' ').filter(Boolean);
 				words.forEach((word) => {
 					if (!word) return;
-
-					if (word.length === 1) {
-						switch (currentToken.token) {
-							case tokens.NEMETH:
-							case tokens.BOLD:
-							case tokens.ITALIC:
-								currentToken.add_character(word);
-								return;
-							default:
-								{
-									const stringToken = currentToken.push(tokens.STRING);
-									stringToken.add_character(word);
-									stringToken.add_character(' ');
-								}
-								return;
-						}
-					}
 
 					let needsStringToken = false;
 					if (currentToken.token === tokens.PARA) {
@@ -562,6 +676,7 @@ export function lex(text) {
 		});
 
 		paraNode.check_for_equation();
+		assignParaChildBrailleRanges(paraNode, para);
 	});
 
 	assignTopLevelBrailleRanges(parseTree, text);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -206,6 +206,71 @@ test('applyLatexEdit falls back to whole-node regeneration when childRangesRelia
 	assert.equal(doc.errors.length, 0);
 });
 
+test('applyLatexEdit on an empty paragraph (zero children) falls back to whole-node regeneration instead of crashing (braille2latex#21)', async () => {
+	// 'HELLO\n\n\n\nWORLD' has a blank line between two paragraphs, which
+	// split('\n\n') turns into a middle PARA with no children at all.
+	// assignParaChildBrailleRanges() must not call that "reliable" just
+	// because spans.length === children.length === 0 -- the old vacuous
+	// match crashed applyLatexEdit's splice path (children[-1] access) the
+	// first time an edit landed in such a paragraph.
+	const doc = await makeDoc('HELLO\n\n\n\nWORLD');
+	assert.equal(doc.topLevelNodes.length, 3);
+	const empty = doc.topLevelNodes[1];
+	assert.equal(empty.children.length, 0);
+	assert.equal(empty.childRangesReliable, false, 'an empty paragraph must never be flagged reliable');
+
+	const oldLatex = doc.latexText;
+	const insertAt = empty.latexRange.start;
+	const newLatex = oldLatex.slice(0, insertAt) + 'X' + oldLatex.slice(insertAt);
+	const result = await doc.applyLatexEdit(newLatex, insertAt + 1);
+
+	assert.equal(result.nodeError, null);
+	assert.equal(doc.errors.length, 0);
+	assert.match(result.brailleText, /X/, 'the inserted character must appear somewhere in the regenerated braille');
+});
+
+test('applyLatexEdit falls back to whole-node regeneration when the edit lands in PARA-level glue outside every child\'s range (braille2latex#21)', async () => {
+	// Same '_.CAN_. DOG' fixture as the braille2latex#19 splice test above, but
+	// the edit lands past the last child's own latexRange -- in the trailing
+	// "\n\n" the PARA case of to_latex() appends *after* stamping children's
+	// ranges (see processFile.js's PARA case). findOwningIndex has no
+	// "out of range" signal, so without the bounds check it would silently
+	// attribute this edit to the DOG child and splice, even though
+	// childRangesReliable is true (unlike the previous test).
+	const forwardCalls = [];
+	const trackingTranslateForward = async (text) => {
+		forwardCalls.push(text);
+		return text + 'X';
+	};
+
+	const doc = await DualDocument.fromBraille('_.CAN_. DOG', {
+		translate: identityTranslate,
+		translateForward: trackingTranslateForward
+	});
+	const para = doc.topLevelNodes[0];
+	assert.equal(para.childRangesReliable, true, 'sanity check: children ARE reliable here, unlike the empty-paragraph case');
+	const [, string] = para.children;
+	assert.equal(string.token, 'STRING');
+
+	const oldLatex = doc.latexText;
+	// One character before the very end of the node's latex range: inside the
+	// trailing "\n\n" glue, past string.latexRange.end.
+	const insertAt = para.latexRange.end - 1;
+	assert.ok(insertAt > string.latexRange.end, 'sanity check: the insert point must be outside every child\'s range');
+	const newLatex = oldLatex.slice(0, insertAt) + 'Z' + oldLatex.slice(insertAt);
+
+	const result = await doc.applyLatexEdit(newLatex, insertAt + 1);
+
+	assert.equal(result.nodeError, null);
+	// Forward translation being called with the BOLD("CAN") content proves the
+	// whole node was regenerated, not just spliced around the DOG child --
+	// the opposite of the braille2latex#19 test's assertion above.
+	assert.ok(
+		forwardCalls.some(call => call.includes(ascii2Braille('CAN'))),
+		'falling back to whole-node regen must re-translate the earlier BOLD child too, not just DOG'
+	);
+});
+
 test('applyLatexEdit on a mixed prose+equation paragraph translates each segment through the right pipeline', async () => {
 	// A word followed by inline math on the same line ("C\n_%ax = b_:") produces a
 	// single PARA node with STRING + NEMETH siblings, NOT a pure EQUATION node —

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { DualDocument } from '../src/index.js';
+import { DualDocument, ascii2Braille } from '../src/index.js';
 
 // Identity stand-ins for liblouis, matching smoke.test.js's convention — these test
 // the sync/splicing/range mechanics, not real braille orthography. Real liblouis
@@ -116,6 +116,87 @@ test('applyLatexEdit spanning multiple top-level nodes is flagged, not silently 
 
 test('applyLatexEdit forward-translates a prose paragraph via an injected translateForward', async () => {
 	const doc = await makeDoc('HELLO');
+	const oldLatex = doc.latexText;
+	const newLatex = oldLatex + ' MORE';
+	const result = await doc.applyLatexEdit(newLatex, newLatex.length);
+
+	assert.equal(result.nodeError, null);
+	assert.ok(result.brailleText.length > 0);
+	assert.equal(doc.errors.length, 0);
+});
+
+test('applyLatexEdit on a PARA with markup preserves an untouched sibling child\'s braille verbatim (braille2latex#19)', async () => {
+	// Non-identity translateForward, tracking every call it receives: the existing
+	// identityTranslateForward can't distinguish "preserved" from "regenerated-
+	// identically" since it just echoes its input back unchanged.
+	const forwardCalls = [];
+	const trackingTranslateForward = async (text) => {
+		forwardCalls.push(text);
+		return text + 'X';
+	};
+
+	const doc = await DualDocument.fromBraille('_.CAN_. DOG', {
+		translate: identityTranslate,
+		translateForward: trackingTranslateForward
+	});
+	const para = doc.topLevelNodes[0];
+	assert.equal(para.token, 'PARA');
+	assert.equal(para.childRangesReliable, true, 'sanity check: this fixture must hit the new splice path');
+	const [bold, string] = para.children;
+	assert.equal(bold.token, 'BOLD');
+	assert.equal(string.token, 'STRING');
+
+	// Edit entirely inside the STRING("DOG") child's latex range, nowhere near BOLD.
+	const oldLatex = doc.latexText;
+	const insertAt = string.latexRange.end;
+	const newLatex = oldLatex.slice(0, insertAt) + 'Z' + oldLatex.slice(insertAt);
+
+	const result = await doc.applyLatexEdit(newLatex, insertAt + 1);
+
+	assert.equal(result.nodeError, null);
+	// The BOLD("CAN") child's raw braille bytes must be byte-identical to before —
+	// proof it was preserved verbatim, not silently re-forward-translated.
+	assert.equal(result.brailleText.startsWith('_.CAN_.'), true);
+	// Forward translation must never even be *called* with the untouched BOLD
+	// child's content — a stronger check than just inspecting the final output.
+	assert.equal(forwardCalls.length, 1);
+	assert.equal(forwardCalls[0].includes(ascii2Braille('CAN')), false);
+});
+
+test('applyLatexEdit deletes a whole Nemeth segment atomically, leaving no orphaned marker or touching the sibling STRING', async () => {
+	// Reuses the existing mixed-prose+equation fixture ('C\n_%ax = b_:', a PARA
+	// with STRING + NEMETH siblings — see the test below). Deleting the entire
+	// math segment must not leave a dangling "_%"/"_:" half of a contraction/
+	// block marker, and must not touch the untouched STRING("C") sibling.
+	const doc = await makeDoc('C\n_%ax = b_:');
+	const para = doc.topLevelNodes[0];
+	assert.equal(para.childRangesReliable, true, 'sanity check: this fixture must hit the new splice path');
+	const [stringChild, nemethChild] = para.children;
+	assert.equal(stringChild.token, 'STRING');
+	assert.equal(nemethChild.token, 'NEMETH');
+
+	const oldLatex = doc.latexText;
+	const newLatex = oldLatex.slice(0, nemethChild.latexRange.start) + oldLatex.slice(nemethChild.latexRange.end);
+
+	const result = await doc.applyLatexEdit(newLatex, nemethChild.latexRange.start);
+
+	assert.equal(result.nodeError, null);
+	assert.doesNotMatch(result.brailleText, /_%/, 'no orphaned Nemeth-open marker after deleting the whole math segment');
+	assert.doesNotMatch(result.brailleText, /_:/, 'no orphaned Nemeth-close marker after deleting the whole math segment');
+	assert.match(result.brailleText, /^C/, 'STRING sibling\'s braille must be untouched by the deletion');
+});
+
+test('applyLatexEdit falls back to whole-node regeneration when childRangesReliable is false, without corrupting anything', async () => {
+	// 'abc_.bold_.' hits a separate, pre-existing lexer quirk (a BOLD marker
+	// landing directly against a word with no space nests it under the STRING
+	// node instead of as a PARA sibling), which the marker-only scanner can't
+	// predict — see the equivalent lex()-level test in smoke.test.js. This proves
+	// the *edit* path degrades safely too, not just the scan/flag itself.
+	const doc = await makeDoc('abc_.bold_.');
+	const para = doc.topLevelNodes[0];
+	assert.equal(para.token, 'PARA');
+	assert.equal(para.childRangesReliable, false, 'sanity check: this fixture must hit the fallback path');
+
 	const oldLatex = doc.latexText;
 	const newLatex = oldLatex + ' MORE';
 	const result = await doc.applyLatexEdit(newLatex, newLatex.length);

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -68,18 +68,45 @@ test('lex() closes a NEMETH block opened mid-line via the word-based branch', ()
 	assert.equal(para.token, 'PARA');
 	const nemeth = para.children.find((c) => c.token === 'NEMETH');
 	assert.ok(nemeth, 'expected a NEMETH child');
-	assert.equal(nemeth.value, 'ax =b', 'NEMETH value must not include the closing "_:" marker');
+	// 'ax = b' preserves the source's literal spacing (matches what the dedicated
+	// character-by-character NEMETH branch would produce for the same content) —
+	// not 'ax =b'. 
+	assert.equal(nemeth.value, 'ax = b', 'NEMETH value must not include the closing "_:" marker');
 
 	// Content typed after the equation must land in a sibling node, not get
 	// absorbed into the (never-closed) NEMETH block.
 	const tree2 = lex('C\n_%ax = b_:\nmore text');
 	const para2 = tree2.children[0];
 	const nemeth2 = para2.children.find((c) => c.token === 'NEMETH');
-	assert.equal(nemeth2.value, 'ax =b');
+	assert.equal(nemeth2.value, 'ax = b');
 	assert.ok(
 		para2.children.some((c) => c.token === 'STRING' && c.value?.includes('more')),
 		'trailing text after the equation must be its own STRING sibling'
 	);
+});
+
+test('lex() does not drop a single-character word after the first word/run in a paragraph', () => {
+	// Regression test for braille2latex#20: a single-character word (e.g. "a")
+	// occurring anywhere after the first word/run used to get nested as a *child*
+	// of the current STRING node instead of merging into it — and to_latex()'s
+	// STRING case never recurses into .children, so the word silently vanished
+	// from the rendered output.
+	const tree = lex('I have a big dog');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 1, 'all words on one unmarked line merge into a single STRING run');
+	assert.equal(para.children[0].value, 'I have a big dog');
+});
+
+test('lex() keeps correct spacing around a single-character word inside a BOLD run', () => {
+	// Regression test for braille2latex#20's secondary symptom: the old special
+	// case for single-character words returned early inside BOLD/ITALIC runs,
+	// skipping the trailing-space append every other word gets — gluing the next
+	// word directly onto it (e.g. "big a dog" rendered as "big adog").
+	const tree = lex('_.big a dog_.');
+	const para = tree.children[0];
+	const bold = para.children.find((c) => c.token === 'BOLD');
+	assert.ok(bold, 'expected a BOLD child');
+	assert.equal(bold.value, 'big a dog');
 });
 
 test('parseWithTranslator() converts plain text to LaTeX without needing liblouis installed', async () => {

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -85,6 +85,24 @@ test('lex() closes a NEMETH block opened mid-line via the word-based branch', ()
 	);
 });
 
+test('lex() inserts a space at a line wrap within a paragraph instead of fusing words', () => {
+	// Regression test: a single '\n' inside a paragraph (as opposed to the '\n\n'
+	// that marks an actual paragraph break) is a line wrap -- e.g. one line per
+	// row of OCR-detected braille cells. Previously the wrap contributed no
+	// separator at all, so "require\nwaiting" rendered as "requirewaiting".
+	const tree = lex('require\nwaiting');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 1);
+	assert.equal(para.children[0].value, 'require waiting');
+
+	// A real paragraph break (blank line) must still NOT gain an extra space --
+	// that boundary already becomes a new PARA, not a joined run.
+	const tree2 = lex('first para\n\nsecond para');
+	assert.equal(tree2.children.length, 2);
+	assert.equal(tree2.children[0].children[0].value, 'first para');
+	assert.equal(tree2.children[1].children[0].value, 'second para');
+});
+
 test('lex() does not drop a single-character word after the first word/run in a paragraph', () => {
 	// Regression test for braille2latex#20: a single-character word (e.g. "a")
 	// occurring anywhere after the first word/run used to get nested as a *child*

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -109,6 +109,48 @@ test('lex() keeps correct spacing around a single-character word inside a BOLD r
 	assert.equal(bold.value, 'big a dog');
 });
 
+test('lex() marks childRangesReliable and stamps correct per-child brailleRange for markup-separated runs', () => {
+	const tree = lex('_.CAN_. DOG');
+	const para = tree.children[0];
+	assert.equal(para.childRangesReliable, true);
+	assert.equal(para.children.length, 2);
+
+	const [bold, string] = para.children;
+	assert.equal(bold.token, 'BOLD');
+	assert.equal(string.token, 'STRING');
+	assert.equal(para.brailleRange.start, 0);
+	const paraRaw = '_.CAN_. DOG';
+	assert.equal(paraRaw.slice(bold.brailleRange.start, bold.brailleRange.end), '_.CAN_.');
+	assert.equal(paraRaw.slice(string.brailleRange.start, string.brailleRange.end), ' DOG');
+});
+
+test('lex() marks childRangesReliable for a plain unmarked paragraph too', () => {
+	// Depends on braille2latex#20's fix: before that fix, "I have a big dog" split
+	// into two top-level STRING children ("I " and "have big dog", with "a" dropped
+	// silently in between) which the marker-only scanner — correctly — wouldn't have
+	// predicted, so this would have been unreliable rather than a real coverage gain.
+	const tree = lex('I have a big dog');
+	const para = tree.children[0];
+	assert.equal(para.childRangesReliable, true);
+	assert.equal(para.children.length, 1);
+	assert.equal(para.children[0].brailleRange.start, 0);
+	assert.equal(para.children[0].brailleRange.end, 'I have a big dog'.length);
+});
+
+test('lex() falls back to childRangesReliable = false when the marker-only scan cannot match the real tree', () => {
+	// "_%3+4_:more" hits a separate, pre-existing lexer quirk: content immediately
+	// following a closing "_:" with no space lands in the (never-rendered) PARA
+	// node's own .value instead of becoming a sibling child — so the real tree has
+	// only one top-level child (the NEMETH node) while the marker-only scanner,
+	// which has no way to know about that quirk, predicts two spans (nemeth + the
+	// trailing text). The mismatch must be caught, not guessed through.
+	const tree = lex('_%3+4_:more');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 1, 'sanity check: the dropped-text quirk really does produce only one child here');
+	assert.equal(para.childRangesReliable, false);
+	assert.equal(para.children[0].brailleRange, null, 'brailleRange must be left unset, not a guessed value');
+});
+
 test('parseWithTranslator() converts plain text to LaTeX without needing liblouis installed', async () => {
 	// Identity translator stands in for a real back-translation backend (liblouis WASM or
 	// lou_translate) — this is the same shape of call the CLI makes, and is the smoke test


### PR DESCRIPTION
Preserves untouched braille cells when editing from the LaTeX pane, instead of regenerating (and silently re-contracting) the whole paragraph.

Fixes #19
Fixes #20

Also hardens the new child-splice path against two edge cases flagged in review: empty paragraphs (zero children) and edits landing in PARA-level glue (e.g. trailing `\n\n`) outside every child's own range — both previously misattributed or crashed; both now fall back to whole-node regeneration and are covered by regression tests.