### PR TITLE
Drop redundant push CI trigger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,6 @@ name: Lint
 
 on:
   pull_request:
-  push:
-    branches-ignore: [main]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   pull_request:
-  push:
-    branches-ignore: [main]
 
 jobs:
   test:


### PR DESCRIPTION
A push to a branch with an open PR fires both `push` and `pull_request`, running the identical lint/test job twice for the same commit. `pull_request:` alone is sufficient here since every branch goes through a PR and none are fork PRs needing the restricted-permission split that `push` normally exists for.