### PR TITLE
Add Pandoc/Markdown support, rename to braille-bridge, fix bold/italic parsing bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @brailletools/braille2latex
+# @brailletools/braille-bridge
 
 JavaScript library and CLI for converting Braille Readiness Format (BRF) files to LaTeX,
 Markdown, or (via [Pandoc](https://pandoc.org/)) any other format Pandoc can write —
@@ -10,17 +10,17 @@ Supports Nemeth math notation and UEB text via [liblouis](https://github.com/lib
 Not yet published to the npm registry. Until then, install directly from GitHub:
 
 ```bash
-npm install github:brailletools/braille2latex
+npm install github:brailletools/braille-bridge
 ```
 
 Once published, the usual form will work:
 
 ```bash
-npm install @brailletools/braille2latex
+npm install @brailletools/braille-bridge
 ```
 
 `configure()` (browser-side back-translation, see below) needs `liblouis.EasyApiAsync`
-loaded as a global via a `<script>` tag; braille2latex has no npm dependency for that.
+loaded as a global via a `<script>` tag; braille-bridge has no npm dependency for that.
 
 This package depends on [`pandoc-wasm`](https://github.com/pandoc/pandoc-wasm) (~56MB
 unpacked) for `convertText()`/`convertToBinaryFormat()`/`convertFromBinaryFormat()` and
@@ -39,7 +39,7 @@ Must be called once before `DualDocument.fromBraille()`/`fromMarkdown()` (or any
 translation in this package that doesn't supply its own `translate`/`translateForward`
 override). Provides the URLs to the liblouis WebAssembly build. Requires
 `liblouis.EasyApiAsync` to already be available as a global — load the vendored
-`easy-api.js` via a `<script>` tag before calling `configure()`; braille2latex doesn't fetch
+`easy-api.js` via a `<script>` tag before calling `configure()`; braille-bridge doesn't fetch
 or inject that script itself (see [Usage in SvelteKit / browser](#usage-in-sveltekit--browser)
 below). `liblouisTablesUrl` is only needed for a "no-tables" build (tables loaded on demand
 rather than compiled in).
@@ -116,7 +116,7 @@ paragraph/equation granularity (not full-document, not character-by-character). 
 the same `lex()`/`to_latex()`/`to_markdown()` tree.
 
 ```js
-import { DualDocument } from '@brailletools/braille2latex';
+import { DualDocument } from '@brailletools/braille-bridge';
 
 const doc = await DualDocument.fromBraille(brfText, { table: 'en-ueb-g2.ctb' });
 doc.brailleText; // current braille source
@@ -154,7 +154,7 @@ throughout this package, for testing without a live liblouis worker.
 
 liblouis's own npm packages (`liblouis`/`liblouis-build`) are unmaintained (years behind current liblouis) and no longer importable as a bundler dependency. Fetch a current browser build instead with
 [`@brailletools/liblouis-env-web`](https://github.com/brailletools/liblouis-env/tree/main/js/packages/web),
-which writes a `manifest.json` describing what it fetched (filenames and build variant vary by pinned upstream commit — read the manifest rather than hardcoding them), then load the vendored `easy-api.js` as a plain `<script>` so it's available as a global before `configure()` runs — braille2latex itself has no dependency on `@brailletools/liblouis-env-web` or on any script-loading mechanism; where static assets live and how they're loaded is app-specific, so that step belongs here, in the consuming app:
+which writes a `manifest.json` describing what it fetched (filenames and build variant vary by pinned upstream commit — read the manifest rather than hardcoding them), then load the vendored `easy-api.js` as a plain `<script>` so it's available as a global before `configure()` runs — braille-bridge itself has no dependency on `@brailletools/liblouis-env-web` or on any script-loading mechanism; where static assets live and how they're loaded is app-specific, so that step belongs here, in the consuming app:
 
 ```json
 // package.json
@@ -172,7 +172,7 @@ which writes a `manifest.json` describing what it fetched (filenames and build v
 ```js
 // +page.svelte
 import { base } from '$app/paths';
-import { configure, whenReady, DualDocument } from '@brailletools/braille2latex';
+import { configure, whenReady, DualDocument } from '@brailletools/braille-bridge';
 import manifest from '../../static/liblouis/manifest.json';
 
 const b = base === '/' ? '' : base;
@@ -191,7 +191,7 @@ const latex = doc.latexText;
 ## Command-line usage
 
 ```bash
-braille2latex <file.brf> [--table TABLE | --dictionary TABLE] [--format FORMAT] [--full-doc] [--braille-only] [-o FILE]
+braille-bridge <file.brf> [--table TABLE | --dictionary TABLE] [--format FORMAT] [--full-doc] [--braille-only] [-o FILE]
 ```
 
 - `--table TABLE` / `--dictionary TABLE` — liblouis table to translate with (default: `en-ueb-g2.ctb`).
@@ -223,10 +223,10 @@ npx liblouis-fetch
 Examples:
 
 ```bash
-braille2latex "Sample Quiz.brf" --full-doc -o quiz.tex
-braille2latex "Sample Quiz.brf" --dictionary en-ueb-g2.ctb
-braille2latex "Sample Quiz.brf" --format rst
-braille2latex "Sample Quiz.brf" --format docx -o quiz.docx
+braille-bridge "Sample Quiz.brf" --full-doc -o quiz.tex
+braille-bridge "Sample Quiz.brf" --dictionary en-ueb-g2.ctb
+braille-bridge "Sample Quiz.brf" --format rst
+braille-bridge "Sample Quiz.brf" --format docx -o quiz.docx
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # @brailletools/braille2latex
 
-JavaScript library and CLI for converting Braille Readiness Format (BRF) files to LaTeX.
+JavaScript library and CLI for converting Braille Readiness Format (BRF) files to LaTeX,
+Markdown, or (via [Pandoc](https://pandoc.org/)) any other format Pandoc can write —
+and for building a live-synced braille⟷LaTeX/Markdown editor (see `DualDocument` below).
 Supports Nemeth math notation and UEB text via [liblouis](https://github.com/liblouis/liblouis.js).
 
 ## Install
@@ -17,38 +19,51 @@ Once published, the usual form will work:
 npm install @brailletools/braille2latex
 ```
 
-For the command tool, `@brailletools/liblouis-env` (resolving `lou_translate`) is its only dependency. `configure()`/`parse()` (browser-side back-translation,
-see below) need `liblouis.EasyApiAsync` loaded as a global via a `<script>` tag; braille2latex has no npm dependency for that either.
+`configure()` (browser-side back-translation, see below) needs `liblouis.EasyApiAsync`
+loaded as a global via a `<script>` tag; braille2latex has no npm dependency for that.
+
+This package depends on [`pandoc-wasm`](https://github.com/pandoc/pandoc-wasm) (~56MB
+unpacked) for `convertText()`/`convertToBinaryFormat()`/`convertFromBinaryFormat()` and
+for the CLI's non-`latex`/`markdown` `--format` values — that's a one-time install-time
+disk cost, not a runtime download cost: in Node it reads its wasm binary straight from
+disk, and in a browser bundler it's only fetched over the network the first time one of
+those functions is actually called (see [`src/pandoc.js`](./src/pandoc.js)'s doc comment —
+a bundler that respects lazy `import()` code-splitting, e.g. Vite, will never fetch it for
+a consumer that never calls those functions at all).
 
 ## API
 
 ### `configure({ liblouisCapiUrl, liblouisEasyApiUrl, liblouisTablesUrl? })`
 
-Must be called once before `parse()`. Provides the URLs to the liblouis WebAssembly build.
-Requires `liblouis.EasyApiAsync` to already be available as a global — load the vendored
+Must be called once before `DualDocument.fromBraille()`/`fromMarkdown()` (or any other
+translation in this package that doesn't supply its own `translate`/`translateForward`
+override). Provides the URLs to the liblouis WebAssembly build. Requires
+`liblouis.EasyApiAsync` to already be available as a global — load the vendored
 `easy-api.js` via a `<script>` tag before calling `configure()`; braille2latex doesn't fetch
 or inject that script itself (see [Usage in SvelteKit / browser](#usage-in-sveltekit--browser)
 below). `liblouisTablesUrl` is only needed for a "no-tables" build (tables loaded on demand
 rather than compiled in).
 
-### `parse(text, table?)`
+### `whenReady()`
 
-Converts a BRF string (ASCII Braille) to LaTeX using the liblouis WASM backend. Returns a
-`Promise<string>`. Requires `configure()` to have been called first.
-
-Default table: `en-ueb-g2.ctb` (English UEB Grade 2).
-
-### `parseWithTranslator(text, table, translate)`
-
-Same as `parse()`, but with a caller-supplied back-translation backend instead of the
-liblouis WASM Easy API — doesn't require `configure()`. `translate(unicodeBraille, table)`
-should return `Promise<string>`. This is what the CLI uses (see below) to back-translate via
-a `lou_translate` binary. 
+Resolves once `configure()` has finished setting up the liblouis backend (or rejects if
+setup failed). Exposed separately for callers that want to gate UI state (e.g. a loading
+indicator) on readiness without triggering a load.
 
 ### `lex(text)`
 
-The underlying BRF tokenizer, shared by `parse()` and `parseWithTranslator()`. Exposed for
-callers who want the parsed token tree without running back-translation.
+The BRF tokenizer — parses braille (ASCII/NABCC) text into the token tree `DualDocument`
+and `Element.to_latex()`/`to_markdown()` operate on. Exposed for callers who want the
+parsed token tree directly, without going through `DualDocument`.
+
+### `fromMarkdown(text, { table?, translateForward? })`
+
+The reverse direction: parses Markdown source into the same token tree shape `lex()`
+builds from braille, forward-translating recognized prose/bold/italic/math into
+braille-ASCII as it goes. Unrecognized Markdown constructs (headings, lists, tables,
+etc.) are never dropped — their raw source is translated like ordinary prose and the
+enclosing paragraph is flagged (see `DualDocument.errors` below). Used internally by
+`DualDocument.fromMarkdown()`.
 
 ### `ascii2Braille(str)` / `braille2Ascii(str)`
 
@@ -67,23 +82,46 @@ input through unchanged — it throws on invalid input, so callers can distingui
 translation available" from "here's a (possibly wrong) result." `options` is
 forwarded to the underlying Abraham parser (e.g. `operatorNames`).
 
+### `translateForward(text, table?)`
+
 Forward-translates print text to Braille-ASCII using the liblouis WASM backend
-configured via `configure()` — the mirror of `parse()`'s back-translation direction.
-Requires `configure()` to have been called first, same as `parse()`. If you need
-Unicode braille glyphs, pass the result through `ascii2Braille()`.
+configured via `configure()` — the mirror of back-translation. Requires `configure()`
+to have been called first. If you need Unicode braille glyphs, pass the result through
+`ascii2Braille()`.
+
+### `convertText(text, from, to, extraOptions?)`
+
+Converts text from one [Pandoc reader format](https://pandoc.org/MANUAL.html#general-options)
+to another Pandoc writer format (e.g. `'latex'` → `'markdown'`, or `'markdown'` → `'rst'`).
+Not for formats that need binary input/output (Word, ODT — see below). `extraOptions` is
+merged verbatim into Pandoc's own options object — e.g. `{ standalone: true }` to wrap the
+output as a complete document instead of a body fragment. Lazily loads `pandoc-wasm` on
+first call (see the note in Install above).
+
+### `convertToBinaryFormat(text, from, to, extraOptions?)`
+
+Converts text to a binary-format document (Word `.docx`, ODT, …) via Pandoc, returning a
+`Blob`. Any Pandoc writer name is accepted.
+
+### `convertFromBinaryFormat(data, from, to, extraOptions?)`
+
+Converts a binary-format document (`Blob`/`ArrayBuffer` — e.g. an uploaded `.docx` file) to
+text via Pandoc. Any Pandoc reader name is accepted.
+
 ### `DualDocument`
 
-A canonical braille⟷LaTeX document model for building a side-by-side editor where
-both representations are directly editable and stay in sync at paragraph/equation
-granularity (not full-document, not character-by-character). Wraps the same `lex()`/
-`to_latex()` tree used by `parse()`.
+A canonical braille⟷LaTeX/Markdown document model for building a side-by-side editor
+where braille and one other format are directly editable and stay in sync at
+paragraph/equation granularity (not full-document, not character-by-character). Wraps
+the same `lex()`/`to_latex()`/`to_markdown()` tree.
 
 ```js
 import { DualDocument } from '@brailletools/braille2latex';
 
 const doc = await DualDocument.fromBraille(brfText, { table: 'en-ueb-g2.ctb' });
 doc.brailleText; // current braille source
-doc.latexText;   // current generated LaTeX
+doc.latexText;   // current generated LaTeX (kept eagerly in sync)
+await doc.renderMarkdown(); // current generated Markdown (rendered on demand, not kept eagerly in sync)
 
 // Apply an edit made in the braille pane (full new value + caret offset):
 const { latexText, latexCursor } = await doc.applyBrailleEdit(newBrailleText, cursorOffset);
@@ -91,18 +129,24 @@ const { latexText, latexCursor } = await doc.applyBrailleEdit(newBrailleText, cu
 // Apply an edit made in the LaTeX pane:
 const { brailleText, brailleCursor, nodeError } = await doc.applyLatexEdit(newLatexText, cursorOffset);
 
-// Nodes currently out of sync (translation failed for that paragraph/equation):
-doc.errors; // [{ nodeId, pane, label, range, message }, ...]
+// Or, symmetrically, an edit made in the Markdown pane (call renderMarkdown() at
+// least once first so its ranges are populated):
+const { brailleText: b2, brailleCursor: c2 } = await doc.applyMarkdownEdit(newMarkdownText, cursorOffset);
+
+// Nodes currently out of sync, or flagged at import time (e.g. an unrecognized
+// Markdown construct — see fromMarkdown() above):
+doc.errors; // [{ nodeId, pane, label, range, brailleRange, message }, ...]
 ```
 
-Both `applyBrailleEdit`/`applyLatexEdit` only re-derive the top-level node(s)
-(paragraph or equation) actually touched by the edit, splice the result into the
-existing text, and return a best-effort proportional cursor position for the other
-pane. On a LaTeX-side translation failure (bad syntax, or an edit spanning more than
-one paragraph/equation — there's no LaTeX lexer to rediscover new boundaries), the
-braille pane is left untouched and the affected node appears in `doc.errors` instead.
-`fromBraille()` accepts the same `translate`/`translateForward` override hooks as
-`parseWithTranslator()`, for testing without a live liblouis worker.
+`applyBrailleEdit`/`applyLatexEdit`/`applyMarkdownEdit` all only re-derive the top-level
+node(s) (paragraph or equation) actually touched by the edit, splice the result into the
+existing text, and return a best-effort proportional cursor position for the other pane
+(`mapCursor()` is also exposed directly for mapping an arbitrary offset on demand). On a
+translation failure (bad syntax, or an edit spanning more than one paragraph/equation —
+there's no LaTeX/Markdown lexer to rediscover new boundaries), the braille pane is left
+untouched and the affected node appears in `doc.errors` instead. `fromBraille()`/
+`fromMarkdown()` accept the same `translate`/`translateForward` override hooks used
+throughout this package, for testing without a live liblouis worker.
 
 ---
 
@@ -128,7 +172,7 @@ which writes a `manifest.json` describing what it fetched (filenames and build v
 ```js
 // +page.svelte
 import { base } from '$app/paths';
-import { configure, parse } from '@brailletools/braille2latex';
+import { configure, whenReady, DualDocument } from '@brailletools/braille2latex';
 import manifest from '../../static/liblouis/manifest.json';
 
 const b = base === '/' ? '' : base;
@@ -138,19 +182,29 @@ configure({
   // Only needed when manifest.variant === 'no-tables':
   liblouisTablesUrl:  `.${b}/liblouis/${manifest.tablesDir}/`,
 });
+await whenReady();
 
-const latex = await parse(brfFileContents);
+const doc = await DualDocument.fromBraille(brfFileContents);
+const latex = doc.latexText;
 ```
 
 ## Command-line usage
 
 ```bash
-braille2latex <file.brf> [--table TABLE | --dictionary TABLE] [--full-doc] [--braille-only] [-o FILE]
+braille2latex <file.brf> [--table TABLE | --dictionary TABLE] [--format FORMAT] [--full-doc] [--braille-only] [-o FILE]
 ```
 
 - `--table TABLE` / `--dictionary TABLE` — liblouis table to translate with (default: `en-ueb-g2.ctb`).
-- `--full-doc` — wrap the output in a complete, compilable LaTeX document (`\documentclass`...`\end{document}`).
-  Without it, only the translated body is printed.
+- `--format FORMAT` — output format (default: `latex`). `latex` and `markdown` are hand-rolled
+  by this package directly (no Pandoc involved). Any other value is treated as a
+  [Pandoc writer name](https://pandoc.org/MANUAL.html#general-options) (e.g. `docx`, `odt`,
+  `rst`, `html`, `epub`) — the braille is rendered to Markdown first, then Pandoc converts
+  Markdown → `FORMAT`. Binary writers (`docx`, `odt`, `pptx`, `epub`, `epub2`, `epub3`)
+  require `-o`, since their output can't sensibly go to stdout.
+- `--full-doc` — wrap the output in a complete document instead of just the translated body.
+  For `latex`/`markdown` this is a hand-rolled wrapper (`\documentclass`...`\end{document}`,
+  or a Markdown frontmatter block); for any Pandoc-routed format it maps to Pandoc's own
+  `standalone` option.
 - `--braille-only` — skip text back-translation entirely and always emit Unicode Braille for text sections
   (no external binary needed; Nemeth math is always converted regardless via the bundled Abraham parser).
 - `-o, --output FILE` — write to `FILE` instead of stdout.
@@ -171,6 +225,8 @@ Examples:
 ```bash
 braille2latex "Sample Quiz.brf" --full-doc -o quiz.tex
 braille2latex "Sample Quiz.brf" --dictionary en-ueb-g2.ctb
+braille2latex "Sample Quiz.brf" --format rst
+braille2latex "Sample Quiz.brf" --format docx -o quiz.docx
 ```
 
 ## Credits

--- a/bin/braille-bridge.js
+++ b/bin/braille-bridge.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// braille2latex — Convert a BRF (ASCII Braille) file to LaTeX, Markdown, or any
+// braille-bridge — Convert a BRF (ASCII Braille) file to LaTeX, Markdown, or any
 // Pandoc-supported format, from the command line.
 //
 // Nemeth math sections are converted via Abraham (pure JS, always available).
@@ -17,7 +17,7 @@
 // actually requested — not on every invocation.
 //
 // Usage:
-//   braille2latex <file.brf> [options]
+//   braille-bridge <file.brf> [options]
 //
 // Options:
 //   --table TABLE, --dictionary TABLE   liblouis table (default: en-ueb-g2.ctb)
@@ -72,7 +72,7 @@ const filePath = args[0];
 
 if (!filePath) {
 	console.error(
-		'Usage: braille2latex <file.brf> [--table TABLE | --dictionary TABLE] [--format FORMAT] [--full-doc] [--braille-only] [-o FILE]'
+		'Usage: braille-bridge <file.brf> [--table TABLE | --dictionary TABLE] [--format FORMAT] [--full-doc] [--braille-only] [-o FILE]'
 	);
 	process.exit(1);
 }
@@ -90,8 +90,8 @@ if (!brailleOnly) {
 	louTranslatePath = resolveLouTranslate();
 	if (!louTranslatePath) {
 		process.stderr.write(
-			'[braille2latex] lou_translate not found; text sections will be shown as Unicode braille.\n' +
-				'[braille2latex] Install it with: npx liblouis-fetch  (or set LOU_TRANSLATE_PATH).\n'
+			'[braille-bridge] lou_translate not found; text sections will be shown as Unicode braille.\n' +
+				'[braille-bridge] Install it with: npx liblouis-fetch  (or set LOU_TRANSLATE_PATH).\n'
 		);
 	}
 }
@@ -156,7 +156,7 @@ if (format === 'latex' || format === 'markdown') {
 			}
 		}
 	} catch (error) {
-		console.error(`[braille2latex] --format ${format} failed: ${error.message}`);
+		console.error(`[braille-bridge] --format ${format} failed: ${error.message}`);
 		process.exit(1);
 	}
 }

--- a/bin/braille-bridge.js
+++ b/bin/braille-bridge.js
@@ -103,7 +103,13 @@ async function translate(unicodeBraille, tbl) {
 			input: unicodeBraille,
 			encoding: 'utf8'
 		});
-		return result.trimEnd();
+		// Strip only a trailing newline (a CLI-output artifact on some platforms/
+		// builds) -- NOT all trailing whitespace. A trailing space can be
+		// meaningful content (e.g. the separator lex() stores at the end of a
+		// STRING node immediately preceding a BOLD/ITALIC/NEMETH span), and
+		// .trimEnd() was silently eating it, reopening the same missing-space bug
+		// that fixing lex() itself was meant to close.
+		return result.replace(/\r?\n+$/, '');
 	} catch {
 		return unicodeBraille;
 	}

--- a/bin/braille2latex.js
+++ b/bin/braille2latex.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// braille2latex — Convert a BRF (ASCII Braille) file to LaTeX from the command line.
+// braille2latex — Convert a BRF (ASCII Braille) file to LaTeX, Markdown, or any
+// Pandoc-supported format, from the command line.
 //
 // Nemeth math sections are converted via Abraham (pure JS, always available).
 // Text sections are back-translated via the system `lou_translate` binary if one
@@ -8,46 +9,77 @@
 // command never installs lou_translate itself — run `npx liblouis-fetch` for a
 // cross-platform way to install it.
 //
+// --format latex/markdown are hand-rolled (no Pandoc involved, matching this
+// package's own to_latex()/to_markdown() renderers). Any other --format value
+// is routed through Pandoc: the braille is first rendered to Markdown, then
+// Pandoc converts Markdown -> <format>. Pandoc's wasm binary (~56MB) is only
+// loaded from local disk (see src/pandoc.js) if a non-latex/markdown format is
+// actually requested — not on every invocation.
+//
 // Usage:
 //   braille2latex <file.brf> [options]
 //
 // Options:
 //   --table TABLE, --dictionary TABLE   liblouis table (default: en-ueb-g2.ctb)
-//   --full-doc                          wrap output in a complete LaTeX document
+//   --format FORMAT                     output format: latex, markdown, or any
+//                                        Pandoc writer name (default: latex)
+//   --full-doc                          wrap output in a complete document
+//                                        (hand-rolled for latex/markdown; Pandoc's
+//                                        `standalone` option for other formats)
 //   --braille-only                      skip text back-translation; always emit Unicode braille
 //   -o, --output FILE                   write output to FILE instead of stdout
+//                                        (required for binary formats like docx/odt/pptx/epub)
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { resolveLouTranslate } from '@brailletools/liblouis-env';
-import { parseWithTranslator } from '../src/index.js';
+import { lex, convertText, convertToBinaryFormat } from '../src/index.js';
+
+// Pandoc writers that produce a binary document rather than text — these
+// can't sensibly be printed to stdout, so -o is required for them.
+const BINARY_FORMATS = new Set(['docx', 'odt', 'pptx', 'epub', 'epub2', 'epub3']);
 
 // ── Argument parsing ────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2);
 
 function flag(name) {
-    const i = args.indexOf(name);
-    if (i !== -1) { args.splice(i, 1); return true; }
-    return false;
+	const i = args.indexOf(name);
+	if (i !== -1) {
+		args.splice(i, 1);
+		return true;
+	}
+	return false;
 }
 function option(names, def) {
-    for (const name of names) {
-        const i = args.indexOf(name);
-        if (i !== -1) { const v = args[i + 1]; args.splice(i, 2); return v; }
-    }
-    return def;
+	for (const name of names) {
+		const i = args.indexOf(name);
+		if (i !== -1) {
+			const v = args[i + 1];
+			args.splice(i, 2);
+			return v;
+		}
+	}
+	return def;
 }
 
 const wantFullDoc = flag('--full-doc');
 const brailleOnly = flag('--braille-only');
-const table        = option(['--table', '--dictionary'], 'en-ueb-g2.ctb');
-const outputPath   = option(['-o', '--output'], null);
-const filePath     = args[0];
+const table = option(['--table', '--dictionary'], 'en-ueb-g2.ctb');
+const format = option(['--format'], 'latex');
+const outputPath = option(['-o', '--output'], null);
+const filePath = args[0];
 
 if (!filePath) {
-    console.error('Usage: braille2latex <file.brf> [--table TABLE | --dictionary TABLE] [--full-doc] [--braille-only] [-o FILE]');
-    process.exit(1);
+	console.error(
+		'Usage: braille2latex <file.brf> [--table TABLE | --dictionary TABLE] [--format FORMAT] [--full-doc] [--braille-only] [-o FILE]'
+	);
+	process.exit(1);
+}
+
+if (BINARY_FORMATS.has(format) && !outputPath) {
+	console.error(`--format ${format} produces a binary document — pass -o FILE to write it somewhere.`);
+	process.exit(1);
 }
 
 // lou_translate resolution (resolve-only — never installs anything) now lives
@@ -55,47 +87,76 @@ if (!filePath) {
 
 let louTranslatePath = null;
 if (!brailleOnly) {
-    louTranslatePath = resolveLouTranslate();
-    if (!louTranslatePath) {
-        process.stderr.write(
-            '[braille2latex] lou_translate not found; text sections will be shown as Unicode braille.\n' +
-            '[braille2latex] Install it with: npx liblouis-fetch  (or set LOU_TRANSLATE_PATH).\n'
-        );
-    }
+	louTranslatePath = resolveLouTranslate();
+	if (!louTranslatePath) {
+		process.stderr.write(
+			'[braille2latex] lou_translate not found; text sections will be shown as Unicode braille.\n' +
+				'[braille2latex] Install it with: npx liblouis-fetch  (or set LOU_TRANSLATE_PATH).\n'
+		);
+	}
 }
 
 async function translate(unicodeBraille, tbl) {
-    if (!louTranslatePath) return unicodeBraille;
-    try {
-        const result = execFileSync(louTranslatePath, ['--backward', tbl], {
-            input: unicodeBraille,
-            encoding: 'utf8',
-        });
-        return result.trimEnd();
-    } catch {
-        return unicodeBraille;
-    }
+	if (!louTranslatePath) return unicodeBraille;
+	try {
+		const result = execFileSync(louTranslatePath, ['--backward', tbl], {
+			input: unicodeBraille,
+			encoding: 'utf8'
+		});
+		return result.trimEnd();
+	} catch {
+		return unicodeBraille;
+	}
 }
 
 // ── Convert ──────────────────────────────────────────────────────────────
 
 const raw = readFileSync(filePath, 'utf8');
-const body = (await parseWithTranslator(raw, table, translate)).trim();
 
-const output = wantFullDoc
-    ? [
-        '\\documentclass{article}',
-        '\\usepackage{amsmath}',
-        '\\begin{document}',
-        '',
-        body,
-        '',
-        '\\end{document}',
-    ].join('\n')
-    : body;
+if (format === 'latex' || format === 'markdown') {
+	const tree = lex(raw);
+	const body = (format === 'markdown' ? await tree.to_markdown(table, translate) : await tree.to_latex(table, translate)).trim();
 
-if (outputPath) {
-    writeFileSync(outputPath, output + '\n');
+	const output = wantFullDoc
+		? format === 'markdown'
+			? ['---', 'title: Untitled', '---', '', body].join('\n')
+			: [
+					'\\documentclass{article}',
+					'\\usepackage{amsmath}',
+					'\\begin{document}',
+					'',
+					body,
+					'',
+					'\\end{document}'
+				].join('\n')
+		: body;
+
+	if (outputPath) {
+		writeFileSync(outputPath, output + '\n');
+	} else {
+		console.log(output);
+	}
 } else {
-    console.log(output);
+	// Any other --format: render to Markdown first, then let Pandoc take it
+	// the rest of the way. This is the same Markdown ⇄ Pandoc "hub" approach
+	// webeditor uses for Word — see src/pandoc.js's doc comment.
+	try {
+		const markdown = (await lex(raw).to_markdown(table, translate)).trim();
+		const extraOptions = wantFullDoc ? { standalone: true } : {};
+
+		if (BINARY_FORMATS.has(format)) {
+			const blob = await convertToBinaryFormat(markdown, 'markdown', format, extraOptions);
+			writeFileSync(outputPath, Buffer.from(await blob.arrayBuffer()));
+		} else {
+			const output = await convertText(markdown, 'markdown', format, extraOptions);
+			if (outputPath) {
+				writeFileSync(outputPath, output);
+			} else {
+				console.log(output);
+			}
+		}
+	} catch (error) {
+		console.error(`[braille2latex] --format ${format} failed: ${error.message}`);
+		process.exit(1);
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@brailletools/braille2latex",
+  "name": "@brailletools/braille-bridge",
   "version": "0.2.0",
   "description": "Braille to LaTeX/Markdown converter (and, via Pandoc, any other format) supporting Nemeth math notation",
   "type": "module",
@@ -7,7 +7,7 @@
     ".": "./src/index.js"
   },
   "bin": {
-    "braille2latex": "./bin/braille2latex.js"
+    "braille-bridge": "./bin/braille-bridge.js"
   },
   "files": [
     "src",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/brailletools/braille2latex"
+    "url": "https://github.com/brailletools/braille-bridge"
   },
   "license": "BSD-3-Clause",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brailletools/braille2latex",
   "version": "0.2.0",
-  "description": "Braille to LaTeX converter supporting Nemeth math notation",
+  "description": "Braille to LaTeX/Markdown converter (and, via Pandoc, any other format) supporting Nemeth math notation",
   "type": "module",
   "exports": {
     ".": "./src/index.js"
@@ -36,6 +36,7 @@
     "globals": "^16.0.0"
   },
   "dependencies": {
-    "@brailletools/liblouis-env": "github:brailletools/liblouis-env#v0.1.1&path:/js/packages/node"
+    "@brailletools/liblouis-env": "github:brailletools/liblouis-env#v0.1.1&path:/js/packages/node",
+    "pandoc-wasm": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@brailletools/liblouis-env':
         specifier: github:brailletools/liblouis-env#v0.1.1&path:/js/packages/node
         version: https://codeload.github.com/brailletools/liblouis-env/tar.gz/b7de53e203eec2c59b42f3236636da0a4e2bf48a#path:/js/packages/node
+      pandoc-wasm:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.0.0
@@ -23,6 +26,9 @@ importers:
         version: 16.5.0
 
 packages:
+
+  '@bjorn3/browser_wasi_shim@0.4.2':
+    resolution: {integrity: sha512-/iHkCVUG3VbcbmEHn5iIUpIrh7a7WPiwZ3sHy4HZKZzBdSadwdddYDZAII2zBvQYV0Lfi8naZngPCN7WPHI/hA==}
 
   '@brailletools/liblouis-env@https://codeload.github.com/brailletools/liblouis-env/tar.gz/b7de53e203eec2c59b42f3236636da0a4e2bf48a#path:/js/packages/node':
     resolution: {path: /js/packages/node, tarball: https://codeload.github.com/brailletools/liblouis-env/tar.gz/b7de53e203eec2c59b42f3236636da0a4e2bf48a}
@@ -314,6 +320,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pandoc-wasm@1.1.0:
+    resolution: {integrity: sha512-IoWBsC/cbSZe71rcRtxXUxG+Auf8aGDHKYOQZA6OdwmUL2xdpQaqrSGhPa+6zfLdSar7cnyAmTWt6KU9n5kBjQ==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -375,6 +384,8 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@bjorn3/browser_wasi_shim@0.4.2': {}
 
   '@brailletools/liblouis-env@https://codeload.github.com/brailletools/liblouis-env/tar.gz/b7de53e203eec2c59b42f3236636da0a4e2bf48a#path:/js/packages/node':
     dependencies:
@@ -667,6 +678,10 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  pandoc-wasm@1.1.0:
+    dependencies:
+      '@bjorn3/browser_wasi_shim': 0.4.2
 
   parent-module@1.0.1:
     dependencies:

--- a/src/brailleMap.js
+++ b/src/brailleMap.js
@@ -153,7 +153,7 @@ export function nemeth_to_latex(text) {
 			}
 			
 		} catch (error) {
-			console.error("Braille2latex failed for braille: " + braille);
+			console.error("braille-bridge failed for braille: " + braille);
 			console.error("Original text: " + line);
 			console.error(error);
 			latex = '';

--- a/src/document.js
+++ b/src/document.js
@@ -11,7 +11,7 @@
 // full-document, not per-character. See processFile.js's assignTopLevelBrailleRanges
 // and the ROOT case of Element.to_latex() for where brailleRange/latexRange come from.
 
-import { lex, tokens, translateForward as defaultTranslateForward } from './processFile.js';
+import { lex, fromMarkdown as parseMarkdown, tokens, translateForward as defaultTranslateForward } from './processFile.js';
 import { latex_to_nemeth } from './brailleMap.js';
 
 const defaultTable = 'en-ueb-g2.ctb';
@@ -76,15 +76,20 @@ function stripProseMarkup(latexSlice) {
 		.replace(/}/g, '');
 }
 
-// A PARA node's latex can mix prose and inline/display math (e.g. "can $ax = b$" —
-// a STRING and a NEMETH child as siblings, which check_for_equation() only promotes
-// to a pure EQUATION node when the PARA has *no other* children — most real
-// documents mix a word with an equation on the same line, so this is the common
-// case, not an edge case). Splits latexSlice into alternating prose/math segments
-// so each can be translated through the right pipeline, instead of forward-
-// translating the whole thing (literal "$"/"\" math syntax included) as if it were
-// plain prose — which silently mistranslates real content instead of erroring.
-function segmentMixedLatex(latexSlice) {
+// A PARA node's latex/markdown can mix prose and inline/display math (e.g.
+// "can $ax = b$" — a STRING and a NEMETH child as siblings, which
+// check_for_equation() only promotes to a pure EQUATION node when the PARA has
+// *no other* children — most real documents mix a word with an equation on the
+// same line, so this is the common case, not an edge case). Splits the slice
+// into alternating prose/math segments so each can be translated through the
+// right pipeline, instead of forward-translating the whole thing (literal
+// "$"/"\" math syntax included) as if it were plain prose — which silently
+// mistranslates real content instead of erroring. Shared by both the LaTeX and
+// Markdown panes: both use the identical $.../$$...$$ math delimiter syntax
+// (Pandoc's Markdown math extension matches LaTeX's), only the surrounding
+// prose markup differs (\textbf{}/\textit{} vs. **/*, stripped separately by
+// stripProseMarkup()/stripMarkdownMarkup() below).
+function segmentMixedMathText(latexSlice) {
 	const s = stripTrailingBlankLines(latexSlice);
 	const segments = [];
 	const re = /\$\$([\s\S]*?)\$\$|\$([^$]*)\$/g;
@@ -112,7 +117,7 @@ function segmentMixedLatex(latexSlice) {
 // replacement string the same way.
 async function regenerateParaBraille(latexText, table, forward) {
 	const parts = [];
-	for (const segment of segmentMixedLatex(latexText)) {
+	for (const segment of segmentMixedMathText(latexText)) {
 		if (segment.type === 'math') {
 			parts.push('_%' + latex_to_nemeth(segment.text) + '_:');
 		} else {
@@ -135,6 +140,32 @@ async function regenerateParaBraille(latexText, table, forward) {
 	return parts.join('');
 }
 
+// Markdown-pane mirror of stripProseMarkup() above: crude **bold**/*italic*
+// unwrap for editing prose from the Markdown pane. Same documented phase-1
+// limitation — doesn't reconstruct BOLD/ITALIC node structure, so editing
+// markup from the Markdown side degrades that node to plain text on the
+// braille side, same as editing \textbf{}/\textit{} from the LaTeX side does.
+function stripMarkdownMarkup(markdownSlice) {
+	return stripTrailingBlankLines(markdownSlice)
+		.replace(/\*\*/g, '')
+		.replace(/\*/g, '');
+}
+
+// Markdown-pane mirror of regenerateParaBraille() above.
+async function regenerateParaBrailleFromMarkdown(markdownText, table, forward) {
+	const parts = [];
+	for (const segment of segmentMixedMathText(markdownText)) {
+		if (segment.type === 'math') {
+			parts.push('_%' + latex_to_nemeth(segment.text) + '_:');
+		} else {
+			const prose = stripMarkdownMarkup(segment.text);
+			if (prose === '') continue;
+			parts.push(await forward(prose, table));
+		}
+	}
+	return parts.join('');
+}
+
 export class DualDocument {
 	constructor({ tree, table, translate, translateForward }) {
 		this._tree = tree;
@@ -144,17 +175,24 @@ export class DualDocument {
 		this._nextDocId = 0;
 		for (const node of this._tree.children) {
 			node.docId = this._nextDocId++;
-			node.status = 'ok';
-			node.errorPane = null;
-			node.errorMessage = null;
+			// Only default to 'ok' if nothing has already flagged this node —
+			// fromMarkdown() (processFile.js) may have already set status/
+			// errorPane/errorMessage on a top-level node for content it couldn't
+			// parse (e.g. an unrecognized block-level Markdown construct), and
+			// that flag must survive construction, not get silently overwritten.
+			if (node.status === undefined) {
+				node.status = 'ok';
+				node.errorPane = null;
+				node.errorMessage = null;
+			}
 		}
 	}
 
 	/**
 	 * Build a DualDocument from braille source, translating the whole thing once.
-	 * translate/translateForward are optional back-/forward-translation overrides
-	 * (mirrors parse()/parseWithTranslator() in processFile.js) — mainly for tests
-	 * that don't want to spin up the liblouis WASM worker. When omitted, translate
+	 * translate/translateForward are optional back-/forward-translation overrides —
+	 * mainly for tests that don't want to spin up the liblouis WASM worker. When
+	 * omitted, translate
 	 * falls back to processFile.js's own liblouis-worker default (requires
 	 * configure() to have been called), and translateForward falls back to this
 	 * module's imported translateForward (same requirement).
@@ -167,12 +205,84 @@ export class DualDocument {
 		return new DualDocument({ tree, table, translate, translateForward });
 	}
 
+	/**
+	 * Build a DualDocument from Markdown source (e.g. an uploaded .md file, or
+	 * the result of running an uploaded .tex/.docx through Pandoc first, then
+	 * to Markdown). Braille is still ground truth afterward — this only
+	 * differs from fromBraille() in *how* the initial braille is derived (see
+	 * processFile.js's fromMarkdown() for the parse). Eagerly renders LaTeX
+	 * once, mirroring fromBraille()'s contract so .latexText/applyLatexEdit()
+	 * are immediately usable — Markdown itself is deliberately NOT
+	 * eagerly (re-)rendered here or by any edit path; call renderMarkdown()
+	 * whenever it's actually needed (the user switches the second pane to
+	 * Markdown, or downloads it) — see the webeditor plan's "Formats are
+	 * rederived lazily" note for why.
+	 * @param {string} text
+	 * @param {{ table?: string, translate?: Function, translateForward?: Function }} [options]
+	 */
+	static async fromMarkdown(text, { table = defaultTable, translate, translateForward } = {}) {
+		const tree = await parseMarkdown(text, { table, translateForward });
+		await tree.to_latex(table, translate);
+		return new DualDocument({ tree, table, translate, translateForward });
+	}
+
 	get brailleText() {
 		return this._tree.sourceText;
 	}
 
+	/**
+	 * Whatever LaTeX was last computed. Kept eagerly current by
+	 * fromBraille()/applyBrailleEdit()/applyLatexEdit() — but NOT by
+	 * applyMarkdownEdit(), which only touches .markdown (see its doc
+	 * comment). If the document's most recent edit came through the Markdown
+	 * pane, this getter can be stale; call renderLatex() instead whenever you
+	 * can't be sure which pane was edited last (e.g. switching the live pane
+	 * back to LaTeX).
+	 */
 	get latexText() {
 		return this._tree.latex;
+	}
+
+	/**
+	 * One-shot render of the current braille tree to LaTeX — recomputes
+	 * .latex/.latexRange for every node from scratch (the same cost as a
+	 * fresh load, not an incremental update). Safe to call any time; the
+	 * result is always current regardless of which pane was edited most
+	 * recently, unlike the .latexText getter above.
+	 * @returns {Promise<string>}
+	 */
+	async renderLatex() {
+		await this._tree.to_latex(this.table, this._translate);
+		return this._tree.latex;
+	}
+
+	/**
+	 * Whatever Markdown was last computed by renderMarkdown()/
+	 * applyMarkdownEdit() (or by fromMarkdown()'s initial parse, though that
+	 * doesn't populate this — see fromMarkdown()'s doc comment). Empty string
+	 * if Markdown has never been rendered for this document yet. Same
+	 * staleness caveat as .latexText, mirrored: NOT kept current by
+	 * applyLatexEdit()/applyBrailleEdit() — call renderMarkdown() instead
+	 * whenever you can't be sure which pane was edited last.
+	 */
+	get markdownText() {
+		return this._tree.markdown;
+	}
+
+	/**
+	 * One-shot render of the current braille tree to Markdown — recomputes
+	 * .markdown/.markdownRange for every node from scratch (the same cost as
+	 * a fresh load, not an incremental update). Call this whenever Markdown
+	 * is actually needed; it is never kept in sync automatically by
+	 * applyBrailleEdit()/applyLatexEdit() the way LaTeX is. Must be called at
+	 * least once (e.g. when the user switches the live pane to Markdown)
+	 * before applyMarkdownEdit() can be used — the latter relies on
+	 * .markdownRange already being populated.
+	 * @returns {Promise<string>}
+	 */
+	async renderMarkdown() {
+		await this._tree.to_markdown(this.table, this._translate);
+		return this._tree.markdown;
 	}
 
 	get topLevelNodes() {
@@ -200,15 +310,32 @@ export class DualDocument {
 		return `${type} ${ordinal}`;
 	}
 
-	/** Current out-of-sync nodes across both directions. Empty when fully synced. */
+	/**
+	 * Current out-of-sync or flagged nodes. Empty when fully synced. Includes
+	 * both live-edit sync errors ('error', e.g. an edit spanning multiple
+	 * paragraphs or invalid math) and import-time content that couldn't be
+	 * semantically parsed ('unsupported', e.g. a Markdown construct
+	 * fromMarkdown() doesn't model — see processFile.js's flagUnsupported())
+	 * — the latter isn't a failure exactly, but the user should still be able
+	 * to see which paragraphs were translated literally rather than parsed.
+	 */
 	get errors() {
 		return this._tree.children
-			.filter((n) => n.status === 'error')
+			.filter((n) => n.status === 'error' || n.status === 'unsupported')
 			.map((n) => ({
 				nodeId: n.docId,
 				pane: n.errorPane,
 				label: this.label(n),
-				range: n.errorPane === 'latex' ? n.latexRange : n.brailleRange,
+				range: n.errorPane === 'latex' ? n.latexRange : n.errorPane === 'markdown' ? n.markdownRange : n.brailleRange,
+				// `range` above can be null: e.g. a Markdown-import-time
+				// 'unsupported' flag (see processFile.js's flagUnsupported())
+				// is stamped before markdownRange has ever been computed, if
+				// the caller hasn't rendered Markdown yet (renderMarkdown()
+				// is lazy — see its doc comment). brailleRange is always
+				// populated regardless, so callers that can't use `range`
+				// directly (see webeditor's focusNode()) have a reliable
+				// fallback instead of silently doing nothing.
+				brailleRange: n.brailleRange,
 				message: n.errorMessage
 			}));
 	}
@@ -232,12 +359,33 @@ export class DualDocument {
 		});
 	}
 
+	// Markdown-pane mirror of _recomputeRanges() above, used by
+	// applyMarkdownEdit() instead of applyLatexEdit()'s.
+	_recomputeRangesMarkdown(brailleText, markdownText) {
+		this._tree.sourceText = brailleText;
+		this._tree.markdown = markdownText;
+		let bCursor = 0;
+		let mCursor = 0;
+		this._tree.children.forEach((node) => {
+			const bWidth = node.brailleRange.end - node.brailleRange.start;
+			const mWidth = node.markdownRange.end - node.markdownRange.start;
+			node.brailleRange = { start: bCursor, end: bCursor + bWidth };
+			node.markdownRange = { start: mCursor, end: mCursor + mWidth };
+			bCursor += bWidth + 2; // '\n\n' separator between braille paragraphs
+			mCursor += mWidth; // markdown top-level ranges are already contiguous
+		});
+	}
+
 	// Best-effort proportional cursor mapping: find the node containing the cursor
 	// in the source pane, apply the same proportional offset within that node's
-	// range in the target pane. Braille contractions and LaTeX command expansion
-	// mean this is NOT exact character-for-character — see plan §3 — but it
-	// reliably keeps the cursor in the right node.
-	_mapCursor(sourceRangeKey, targetRangeKey, cursorOffset) {
+	// range in the target pane. Braille contractions and LaTeX/Markdown command
+	// expansion mean this is NOT exact character-for-character — see plan §3 —
+	// but it reliably keeps the cursor in the right node. Public (not just used
+	// internally by applyBrailleEdit()/applyLatexEdit()/applyMarkdownEdit()) —
+	// also the basis for the webeditor "jump to corresponding location in the
+	// other pane" keyboard shortcut, which needs the same mapping on demand,
+	// outside of an edit.
+	mapCursor(sourceRangeKey, targetRangeKey, cursorOffset) {
 		const nodes = this._tree.children;
 		if (nodes.length === 0) return 0;
 		const node = nodes[findOwningIndex(nodes, sourceRangeKey, cursorOffset)];
@@ -260,7 +408,7 @@ export class DualDocument {
 	 */
 	async applyBrailleEdit(newBrailleText, cursorOffset) {
 		if (newBrailleText === this.brailleText) {
-			return { latexText: this.latexText, latexCursor: this._mapCursor('brailleRange', 'latexRange', cursorOffset) };
+			return { latexText: this.latexText, latexCursor: this.mapCursor('brailleRange', 'latexRange', cursorOffset) };
 		}
 
 		const oldBrailleText = this.brailleText;
@@ -296,7 +444,7 @@ export class DualDocument {
 		nodes.splice(firstIdx, lastIdx - firstIdx + 1, ...subtree.children);
 		this._recomputeRanges(newBrailleText, newLatexText);
 
-		return { latexText: this.latexText, latexCursor: this._mapCursor('brailleRange', 'latexRange', cursorOffset) };
+		return { latexText: this.latexText, latexCursor: this.mapCursor('brailleRange', 'latexRange', cursorOffset) };
 	}
 
 	/**
@@ -313,7 +461,7 @@ export class DualDocument {
 		if (newLatexText === this.latexText) {
 			return {
 				brailleText: this.brailleText,
-				brailleCursor: this._mapCursor('latexRange', 'brailleRange', cursorOffset),
+				brailleCursor: this.mapCursor('latexRange', 'brailleRange', cursorOffset),
 				nodeError: null
 			};
 		}
@@ -350,7 +498,7 @@ export class DualDocument {
 			this._recomputeRanges(this.brailleText, newLatexText);
 			return {
 				brailleText: this.brailleText,
-				brailleCursor: this._mapCursor('latexRange', 'brailleRange', cursorOffset),
+				brailleCursor: this.mapCursor('latexRange', 'brailleRange', cursorOffset),
 				nodeError: message
 			};
 		}
@@ -432,7 +580,7 @@ export class DualDocument {
 			this._recomputeRanges(this.brailleText, newLatexText);
 			return {
 				brailleText: this.brailleText,
-				brailleCursor: this._mapCursor('latexRange', 'brailleRange', cursorOffset),
+				brailleCursor: this.mapCursor('latexRange', 'brailleRange', cursorOffset),
 				nodeError: node.errorMessage
 			};
 		}
@@ -458,7 +606,152 @@ export class DualDocument {
 
 		return {
 			brailleText: this.brailleText,
-			brailleCursor: this._mapCursor('latexRange', 'brailleRange', cursorOffset),
+			brailleCursor: this.mapCursor('latexRange', 'brailleRange', cursorOffset),
+			nodeError: null
+		};
+	}
+
+	/**
+	 * Markdown-pane mirror of applyLatexEdit() above — same bounded,
+	 * single-top-level-node edit model (see that method's doc comment for the
+	 * full rationale), substituting Markdown's emphasis markers (asterisk
+	 * pairs for bold, single asterisks for italic) for LaTeX's \textbf{}/
+	 * \textit{} (math delimiters are identical in both, so
+	 * extractMathBody()/segmentMixedMathText() are reused as-is). Requires
+	 * renderMarkdown() to have been called at least once first — see its doc
+	 * comment.
+	 * @returns {Promise<{ brailleText: string, brailleCursor: number, nodeError: string|null }>}
+	 */
+	async applyMarkdownEdit(newMarkdownText, cursorOffset) {
+		if (newMarkdownText === this.markdownText) {
+			return {
+				brailleText: this.brailleText,
+				brailleCursor: this.mapCursor('markdownRange', 'brailleRange', cursorOffset),
+				nodeError: null
+			};
+		}
+
+		const oldMarkdownText = this.markdownText;
+		const { prefixLen, suffixLen } = diffRegion(oldMarkdownText, newMarkdownText);
+		const oldEditStart = prefixLen;
+		const oldEditEnd = oldMarkdownText.length - suffixLen;
+
+		const nodes = this._tree.children;
+		const firstIdx = findOwningIndex(nodes, 'markdownRange', oldEditStart);
+		const lastIdx = oldEditEnd > oldEditStart ? findOwningIndex(nodes, 'markdownRange', oldEditEnd - 1) : firstIdx;
+
+		if (firstIdx !== lastIdx) {
+			const message =
+				'Edit spans multiple paragraphs/equations — narrow the edit to a single paragraph or equation to sync.';
+			for (let i = firstIdx; i <= lastIdx; i++) {
+				nodes[i].status = 'error';
+				nodes[i].errorPane = 'markdown';
+				nodes[i].errorMessage = message;
+			}
+
+			const delta = newMarkdownText.length - oldMarkdownText.length;
+			const last = nodes[lastIdx];
+			last.markdownRange = {
+				start: last.markdownRange.start,
+				end: Math.max(last.markdownRange.start, last.markdownRange.end + delta)
+			};
+			this._recomputeRangesMarkdown(this.brailleText, newMarkdownText);
+			return {
+				brailleText: this.brailleText,
+				brailleCursor: this.mapCursor('markdownRange', 'brailleRange', cursorOffset),
+				nodeError: message
+			};
+		}
+
+		const node = nodes[firstIdx];
+		const delta = newMarkdownText.length - oldMarkdownText.length;
+		const regionMarkdownStart = node.markdownRange.start;
+		const regionMarkdownNewEnd = node.markdownRange.end + delta;
+		const markdownSlice = newMarkdownText.slice(regionMarkdownStart, regionMarkdownNewEnd);
+
+		let newBrailleForNode;
+		try {
+			if (node.token === tokens.EQUATION) {
+				const mathBody = extractMathBody(markdownSlice);
+				newBrailleForNode = '_%' + latex_to_nemeth(mathBody) + '_:';
+			} else {
+				const children = node.children;
+				const { prefixLen: childPrefixLen, suffixLen: childSuffixLen } = diffRegion(node.markdown, markdownSlice);
+				const oldChildRegionStart = childPrefixLen;
+				const oldChildRegionEnd = node.markdown.length - childSuffixLen;
+
+				const canSplice =
+					node.childRangesReliable === true &&
+					children.length > 0 &&
+					oldChildRegionStart >= children[0].markdownRange.start &&
+					oldChildRegionEnd <= children[children.length - 1].markdownRange.end;
+
+				if (canSplice) {
+					const forward = this._translateForward || defaultTranslateForward;
+					const childFirstIdx = findOwningIndex(children, 'markdownRange', oldChildRegionStart);
+					const childLastIdx =
+						oldChildRegionEnd > oldChildRegionStart
+							? findOwningIndex(children, 'markdownRange', oldChildRegionEnd - 1)
+							: childFirstIdx;
+
+					const childRegionStart = children[childFirstIdx].markdownRange.start;
+					const childRegionNewEnd = children[childLastIdx].markdownRange.end + delta;
+					const newChildRegionMarkdown = markdownSlice.slice(childRegionStart, childRegionNewEnd);
+
+					const newBrailleForChildRegion = await regenerateParaBrailleFromMarkdown(
+						newChildRegionMarkdown,
+						this.table,
+						forward
+					);
+
+					const oldNodeBrailleText = this.brailleText.slice(node.brailleRange.start, node.brailleRange.end);
+					const childBrailleStart = children[childFirstIdx].brailleRange.start;
+					const childBrailleOldEnd = children[childLastIdx].brailleRange.end;
+					newBrailleForNode =
+						oldNodeBrailleText.slice(0, childBrailleStart) +
+						newBrailleForChildRegion +
+						oldNodeBrailleText.slice(childBrailleOldEnd);
+				} else {
+					const forward = this._translateForward || defaultTranslateForward;
+					newBrailleForNode = await regenerateParaBrailleFromMarkdown(markdownSlice, this.table, forward);
+				}
+			}
+		} catch (error) {
+			node.status = 'error';
+			node.errorPane = 'markdown';
+			node.errorMessage = error?.message || String(error);
+			node.markdownRange = { start: regionMarkdownStart, end: regionMarkdownNewEnd };
+			this._recomputeRangesMarkdown(this.brailleText, newMarkdownText);
+			return {
+				brailleText: this.brailleText,
+				brailleCursor: this.mapCursor('markdownRange', 'brailleRange', cursorOffset),
+				nodeError: node.errorMessage
+			};
+		}
+
+		const oldBrailleStart = node.brailleRange.start;
+		const oldBrailleEnd = node.brailleRange.end;
+		const newBrailleText =
+			this.brailleText.slice(0, oldBrailleStart) + newBrailleForNode + this.brailleText.slice(oldBrailleEnd);
+
+		const subtree = lex(newBrailleForNode);
+		await subtree.to_markdown(this.table, this._translate);
+		const replacement = subtree.children[0];
+		replacement.docId = node.docId;
+		replacement.status = 'ok';
+		replacement.errorPane = null;
+		replacement.errorMessage = null;
+		// Keep markdown ranges consistent with the user-edited Markdown pane
+		// (newMarkdownText), not the regenerated markdown (subtree.markdown),
+		// which may normalize whitespace/markup.
+		replacement.markdownRange = { start: 0, end: markdownSlice.length };
+		nodes[firstIdx] = replacement;
+
+		this._recomputeRangesMarkdown(newBrailleText, newMarkdownText);
+
+		return {
+			brailleText: this.brailleText,
+			brailleCursor: this.mapCursor('markdownRange', 'brailleRange', cursorOffset),
 			nodeError: null
 		};
 	}

--- a/src/document.js
+++ b/src/document.js
@@ -2,7 +2,7 @@
 // DualDocument: a canonical braille<->LaTeX document model that keeps both
 // representations, plus per-top-level-node status, in sync at paragraph/equation
 // granularity. Built on top of processFile.js's existing Element tree (lex()/
-// to_latex()) rather than replacing it — see braille2latex README and the
+// to_latex()) rather than replacing it — see braille-bridge README and the
 // webeditor side-by-side sync plan for the rationale.
 //
 // Terminology: "top-level nodes" are ROOT's direct children (PARA or EQUATION,

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
-export { configure, whenReady, parse, parseWithTranslator, lex, tokens, translateForward } from './processFile.js';
+export { configure, whenReady, fromMarkdown, lex, tokens, translateForward } from './processFile.js';
 export { nemeth_to_latex, latex_to_nemeth, ascii2Braille, braille2Ascii } from './brailleMap.js';
 export { DualDocument } from './document.js';
+// pandoc.js's own top-level code has no side effects (no eager `import('pandoc-wasm')` —
+// see its doc comment) so re-exporting it here doesn't pull the ~56MB pandoc-wasm binary
+// into anything that merely imports this package; it's only fetched if a consumer
+// actually calls one of these functions.
+export { convertText, convertToBinaryFormat, convertFromBinaryFormat } from './pandoc.js';

--- a/src/pandoc.js
+++ b/src/pandoc.js
@@ -1,0 +1,96 @@
+// @ts-nocheck
+// Thin, lazily-loaded wrapper around pandoc-wasm's convert(). pandoc-wasm's
+// browser entry does a top-level `await import('./pandoc.wasm')` the instant
+// its own module is evaluated — there's no built-in laziness, and the wasm
+// binary is ~56MB — so this module exists specifically to make sure
+// 'pandoc-wasm' itself is only ever dynamically imported on first actual use,
+// never eagerly just because something imported this file (or, transitively,
+// this whole package). Consuming bundlers (e.g. Vite) correctly code-split a
+// lazy `import()` like loadPandoc()'s into its own chunk, only fetched if a
+// function here is actually called — so depending on this module does NOT
+// pull pandoc-wasm's ~56MB into a browser bundle by itself. A consuming
+// bundler will still need its own build-side config for pandoc-wasm's wasm
+// asset + top-level-await syntax regardless of where in the source tree the
+// import lives (see webeditor/vite.config.js's build.target/assetsInclude
+// for a worked example, and its doc comments for why).
+//
+// Node's entry point (used automatically when this file is imported from
+// Node, e.g. by bin/braille2latex.js) reads the wasm binary straight from
+// disk (already unpacked by npm/pnpm install) — no network fetch, no
+// top-level-await bundler restrictions, nothing extra to configure there.
+//
+// API notes (verified empirically against pandoc-wasm 1.1.0, since its README
+// examples for binary input formats are incomplete): convert(options, stdin,
+// files) takes the *text* input via `stdin` for text formats (e.g. latex,
+// markdown), but binary input formats (e.g. docx) require BOTH the file's
+// bytes in `files` AND its name repeated in `options['input-files']` --
+// passing it only via `files` silently produces a "not enough bytes" error
+// instead of reading the file.
+
+/** @type {Promise<typeof import('pandoc-wasm')> | null} */
+let pandocModulePromise = null;
+
+function loadPandoc() {
+	if (!pandocModulePromise) {
+		pandocModulePromise = import('pandoc-wasm');
+	}
+	return pandocModulePromise;
+}
+
+/**
+ * Converts text from one Pandoc-supported text format to another (e.g. LaTeX
+ * -> Markdown, or Markdown -> reStructuredText). Not for formats that need
+ * binary input/output (e.g. Word, ODT) — use convertToBinaryFormat()/
+ * convertFromBinaryFormat() for those.
+ * @param {string} text
+ * @param {string} from - Pandoc reader format name (e.g. 'latex', 'markdown')
+ * @param {string} to - Pandoc writer format name (e.g. 'markdown', 'rst')
+ * @param {object} [extraOptions] - additional Pandoc options merged in verbatim
+ *   (e.g. `{ standalone: true }` to wrap the output as a complete document
+ *   instead of a body fragment)
+ * @returns {Promise<string>}
+ */
+export async function convertText(text, from, to, extraOptions = {}) {
+	const { convert } = await loadPandoc();
+	const result = await convert({ from, to, ...extraOptions }, text, {});
+	if (result.stderr) throw new Error(result.stderr);
+	return result.stdout;
+}
+
+/**
+ * Converts text to a binary-format document (e.g. Word .docx, ODT) via
+ * Pandoc. Any Pandoc writer name is accepted, not just docx — this is the
+ * generic path for target formats that can't just be a stdout string.
+ * @param {string} text
+ * @param {string} from - Pandoc reader format name (e.g. 'markdown')
+ * @param {string} to - Pandoc writer format name (e.g. 'docx', 'odt')
+ * @param {object} [extraOptions] - additional Pandoc options merged in verbatim
+ * @returns {Promise<Blob>}
+ */
+export async function convertToBinaryFormat(text, from, to, extraOptions = {}) {
+	const { convert } = await loadPandoc();
+	const outputFile = `output.${to}`;
+	const result = await convert({ from, to, 'output-file': outputFile, ...extraOptions }, text, {});
+	if (result.stderr) throw new Error(result.stderr);
+	const blob = result.files[outputFile];
+	if (!blob) throw new Error(`Conversion to ${to} produced no output file.`);
+	return blob;
+}
+
+/**
+ * Converts a binary-format document (e.g. an uploaded Word .docx file) to
+ * text, via Pandoc. Any Pandoc reader name is accepted, not just docx.
+ * @param {ArrayBuffer | Blob} data
+ * @param {string} from - Pandoc reader format name (e.g. 'docx', 'odt')
+ * @param {string} to - Pandoc writer format name (e.g. 'markdown')
+ * @param {object} [extraOptions] - additional Pandoc options merged in verbatim
+ * @returns {Promise<string>}
+ */
+export async function convertFromBinaryFormat(data, from, to, extraOptions = {}) {
+	const { convert } = await loadPandoc();
+	const inputFile = `input.${from}`;
+	const blob = data instanceof Blob ? data : new Blob([data]);
+	const result = await convert({ from, to, 'input-files': [inputFile], ...extraOptions }, null, { [inputFile]: blob });
+	if (result.stderr) throw new Error(result.stderr);
+	return result.stdout;
+}

--- a/src/pandoc.js
+++ b/src/pandoc.js
@@ -15,7 +15,7 @@
 // for a worked example, and its doc comments for why).
 //
 // Node's entry point (used automatically when this file is imported from
-// Node, e.g. by bin/braille2latex.js) reads the wasm binary straight from
+// Node, e.g. by bin/braille-bridge.js) reads the wasm binary straight from
 // disk (already unpacked by npm/pnpm install) — no network fetch, no
 // top-level-await bundler restrictions, nothing extra to configure there.
 //

--- a/src/processFile.js
+++ b/src/processFile.js
@@ -1,11 +1,13 @@
 // @ts-nocheck
-import { nemeth_to_latex, ascii2Braille } from './brailleMap.js';
+import { nemeth_to_latex, latex_to_nemeth, ascii2Braille } from './brailleMap.js';
 
 let asyncLiblouis = null;
 let liblouisReadyPromise = null;
 
 /**
- * Configure the liblouis backend. Must be called before parse().
+ * Configure the liblouis backend. Must be called before DualDocument.fromBraille()/
+ * fromMarkdown() (or any other translation in this package that doesn't supply
+ * its own translate/translateForward override).
  *
  * Expects `globalThis.LiblouisEasyApiAsync` to already be available — load the
  * vendored easy-api.js (fetched at build time by @brailletools/liblouis-env-web's
@@ -70,9 +72,10 @@ export function configure({ liblouisCapiUrl, liblouisEasyApiUrl, liblouisTablesU
 
 /**
  * Resolves once configure() has finished setting up the liblouis backend (or
- * rejects if setup failed). parse() already awaits this internally before
- * translating — this is exposed separately for callers that want to gate UI
- * state (e.g. a loading indicator) on readiness without triggering a parse.
+ * rejects if setup failed). DualDocument.fromBraille()/fromMarkdown() already
+ * await this internally before translating — this is exposed separately for
+ * callers that want to gate UI state (e.g. a loading indicator) on readiness
+ * without triggering a load.
  *
  * @returns {Promise<void>}
  */
@@ -85,8 +88,9 @@ export function whenReady() {
 const defaultTable = 'en-ueb-g2.ctb';
 
 // Default translate(unicodeBraille, table) backend: the liblouis WASM Easy API
-// configured via configure(). Callers with a different backend (e.g. the CLI's
-// lou_translate binary) pass their own translate function to to_latex()/parseWithTranslator().
+// configured via configure(). Callers with a different backend (e.g. tests, or
+// a non-browser translation source) pass their own translate function to
+// to_latex()/DualDocument.fromBraille() instead.
 async function defaultLiblouisTranslate(unicodeBraille, table) {
 	return await new Promise((resolve, reject) => {
 		const timeoutId = setTimeout(() => {
@@ -193,18 +197,30 @@ class Element {
 		this.value = undefined; // text content for STRING/NEMETH/etc.
 		this.children = []; // nested token nodes
 		this.parent = parent; // parent node pointer
-		// Offsets into the braille source / generated LaTeX string. Only populated
-		// for top-level (ROOT-child) nodes — see assignTopLevelBrailleRanges() and
-		// the ROOT case of to_latex().
+		// Offsets into the braille source / generated LaTeX or Markdown string.
+		// Only populated for top-level (ROOT-child) nodes — see
+		// assignTopLevelBrailleRanges() and the ROOT case of to_latex()/
+		// to_markdown(). latexRange/markdownRange are populated lazily, only for
+		// whichever format was most recently rendered (see DualDocument's
+		// renderLatex()/renderMarkdown()/setLiveFormat() in document.js) — this
+		// package doesn't keep both eagerly in sync.
 		this.brailleRange = null;
 		this.latexRange = null;
+		this.markdownRange = null;
 		// PARA nodes only: true once assignParaChildBrailleRanges() has verified its
 		// marker-only boundary scan exactly matches this node's real children (count
 		// + token-type-in-order), meaning every child's brailleRange above is safe to
 		// use for splicing. Left undefined (falsy) otherwise -- applyLatexEdit treats
 		// that as "fall back to regenerating the whole node," never guesses.
 		this.childRangesReliable = undefined;
+		// Top-level nodes built by fromMarkdown() only: the exact source slice this
+		// node was parsed from, verbatim. Not read by anything in this package yet —
+		// seeded for a future "ground truth format" feature (see the webeditor
+		// plan's "Round-trip fidelity" notes) so re-exporting an imported document
+		// won't need to retrofit the import path to recover this later.
+		this.importedSource = undefined;
 		this.reset_latex();
+		this.reset_markdown();
 	}
 
 	push(token) {
@@ -257,6 +273,18 @@ class Element {
 		return this.latex;
 	}
 
+	async add_markdown(string) {
+		this.markdown += string;
+	}
+
+	async reset_markdown() {
+		this.markdown = '';
+	}
+
+	get_markdown() {
+		return this.markdown;
+	}
+
 	// Back-translates this node's own .value (used by STRING, BOLD, and ITALIC
 	// nodes, which all hold their text directly rather than in child nodes).
 	// Falls back to the raw ASCII value if conversion or translation fails.
@@ -280,7 +308,7 @@ class Element {
 	async to_latex(table = defaultTable, translate = defaultLiblouisTranslate) {
 		// Walk the tree and build LaTeX using the chosen translation table.
 		// translate(unicodeBraille, table) back-translates a STRING node's text;
-		// defaults to the liblouis WASM backend used by configure()/parse().
+		// defaults to the liblouis WASM backend set up via configure().
 		this.reset_latex();
 		switch (this.token) {
 			case tokens.ROOT:
@@ -385,32 +413,105 @@ class Element {
 		}
 		return this.get_latex();
 	}
-}
 
-export async function parse(text, table = defaultTable) {
-	if (typeof text !== 'string') throw new Error('Input must be a string');
-	if (!liblouisReadyPromise) throw new Error('Call configure() before parse()');
-
-	await liblouisReadyPromise;
-        const parseTree = lex(text);
-	return await parseTree.to_latex(table);
-}
-
-/**
- * Like parse(), but for callers supplying their own back-translation backend
- * instead of the liblouis WASM Easy API (e.g. the CLI, which shells out to
- * lou_translate). Does not require configure() to have been called.
- *
- * @param {string} text
- * @param {string} table - liblouis table name
- * @param {(unicodeBraille: string, table: string) => Promise<string>} translate
- */
-export async function parseWithTranslator(text, table = defaultTable, translate) {
-	if (typeof text !== 'string') throw new Error('Input must be a string');
-	if (typeof translate !== 'function') throw new Error('parseWithTranslator requires a translate(unicodeBraille, table) function');
-
-	const parseTree = lex(text);
-	return await parseTree.to_latex(table, translate);
+	// Renders the same tree to Markdown instead of LaTeX. Structurally a sibling
+	// of to_latex() above (same walk, same per-node startLen/childLatex-style
+	// range bookkeeping) — kept as its own parallel switch rather than a shared
+	// abstraction, since the two grammars only really agree on the math
+	// delimiters (Pandoc's Markdown math extension uses the identical
+	// $...$/$$...$$ syntax we already emit for LaTeX, so nemeth_to_latex() is
+	// reused as-is here too).
+	async to_markdown(table = defaultTable, translate = defaultLiblouisTranslate) {
+		this.reset_markdown();
+		switch (this.token) {
+			case tokens.ROOT:
+				for (const child of this.children) {
+					try {
+						const startLen = this.markdown.length;
+						const childMarkdown = await child.to_markdown(table, translate);
+						this.add_markdown(childMarkdown);
+						child.markdownRange = { start: startLen, end: startLen + childMarkdown.length };
+					} catch (error) {
+						console.error('[processFile] Error processing ROOT child:', error.message, 'token:', child.token);
+					}
+				}
+				break;
+			case tokens.PARA:
+				for (const child of this.children) {
+					try {
+						const childMarkdown = await child.to_markdown(table, translate);
+						const startsWithDisplayMath = /^\s*\$\$/.test(childMarkdown);
+						if (startsWithDisplayMath && this.markdown.length > 0 && !this.markdown.endsWith('\n\n')) {
+							this.add_markdown('\n\n');
+						}
+						const startLen = this.markdown.length;
+						this.add_markdown(childMarkdown);
+						child.markdownRange = { start: startLen, end: startLen + childMarkdown.length };
+					} catch (error) {
+						console.error('[processFile] Error processing PARA child:', error.message, 'token:', child.token);
+					}
+				}
+				this.add_markdown('\n\n');
+				break;
+			case tokens.NEMETH: {
+				const nemethLines = (this.value || '').split('\n');
+				if (nemethLines.length > 1) {
+					if (this.markdown.length > 0 && !this.markdown.endsWith('\n\n')) {
+						this.add_markdown('\n');
+					}
+					nemethLines.forEach((line) => {
+						const md = nemeth_to_latex(line);
+						if (md && md.trim() !== '') {
+							this.add_markdown('$$' + md + '$$\n');
+						}
+					});
+				} else {
+					this.add_markdown('$' + nemeth_to_latex(this.value || '') + '$');
+				}
+				break;
+			}
+			case tokens.EQUATION:
+				for (const child of this.children) {
+					try {
+						this.add_markdown(await child.to_markdown(table, translate));
+					} catch (error) {
+						console.error('[processFile] Error processing EQUATION child:', error.message, 'token:', child.token);
+					}
+				}
+				this.add_markdown('\n\n');
+				break;
+			case tokens.BOLD:
+				this.add_markdown('**');
+				if (this.value) this.add_markdown(await this.translate_value(table, translate));
+				for (const child of this.children) {
+					try {
+						this.add_markdown(await child.to_markdown(table, translate));
+					} catch (error) {
+						console.error('[processFile] Error processing BOLD child:', error.message, 'token:', child.token);
+					}
+				}
+				this.add_markdown('**');
+				break;
+			case tokens.ITALIC:
+				this.add_markdown('*');
+				if (this.value) this.add_markdown(await this.translate_value(table, translate));
+				for (const child of this.children) {
+					try {
+						this.add_markdown(await child.to_markdown(table, translate));
+					} catch (error) {
+						console.error('[processFile] Error processing ITALIC child:', error.message, 'token:', child.token);
+					}
+				}
+				this.add_markdown('*');
+				break;
+			case tokens.STRING:
+				if (this.value) this.add_markdown(await this.translate_value(table, translate));
+				break;
+			default:
+				console.info('Unknown token: ' + this.token);
+		}
+		return this.get_markdown();
+	}
 }
 
 // Top-level (ROOT-child) node ranges only — the granularity DualDocument's
@@ -695,6 +796,210 @@ export function lex(text) {
 
 	assignTopLevelBrailleRanges(parseTree, text);
 	parseTree.sourceText = text; // normalized (\n-only) — ranges above are relative to this, not the raw input
+
+	return parseTree;
+}
+
+// --- Markdown import (Markdown -> Element tree) -----------------------
+//
+// The reverse direction of to_markdown(): builds the same tree shape lex()
+// produces, but starting from Markdown source instead of NABCC braille text.
+// Unlike lex() (pure structural parsing -- the input is already braille, so
+// no translation happens until to_latex()/to_markdown() is called later),
+// this function actively forward-translates print text to braille-ASCII
+// while parsing, since Markdown is print text, not braille.
+
+// Same $...$/$$...$$ math delimiters segmentMixedLatex()/extractMathBody()
+// in document.js already recognize for LaTeX -- Pandoc's default Markdown
+// math extension uses identical syntax, so braille2latex speaks one math
+// delimiter dialect across both target formats.
+const MARKDOWN_MATH_RE = /\$\$([\s\S]*?)\$\$|\$([^$\n]*)\$/g;
+
+// Bold/italic: **bold** / *italic*, the CommonMark/Pandoc-default emphasis
+// markers to_markdown() emits and this function expects back. Underscore
+// style (__bold__/_italic_) is intentionally not recognized here -- it falls
+// through to plain forward-translated text like any other unrecognized
+// construct, per the "never strip, just translate directly" policy below.
+// Known limitation, not attempted here: real CommonMark emphasis "flanking"
+// rules (to correctly tell `3 * 4 and 5 * 6` apart from actual italics) --
+// this uses a simpler greedy-earliest-match heuristic instead.
+const MARKDOWN_BOLD_RE = /\*\*([\s\S]+?)\*\*/;
+const MARKDOWN_ITALIC_RE = /\*([^*\n]+)\*/;
+
+// Block-level constructs this parser doesn't model structurally: headings,
+// lists, blockquotes, code fences/indented code, tables, horizontal rules,
+// footnote definitions. A whole paragraph matching one of these shapes isn't
+// segmented into bold/italic/math spans -- per the "never strip, translate
+// directly" decision, it's forward-translated as one literal run instead,
+// and flagged (see flagUnsupported()) so the sync-issues UI surfaces it
+// rather than the user losing track of what happened to that paragraph. A
+// deliberately coarse heuristic, not a full block-structure parser: good
+// enough for the common shapes Pandoc emits converting a real Word/LaTeX
+// document, not a guarantee of catching every case.
+const MARKDOWN_UNSUPPORTED_BLOCK_RE =
+	/^(#{1,6}\s|>|```|~~~|\s{4}\S|[-*+]\s|\d+\.\s|\|.*\|\s*$|-{3,}\s*$|\[\^[^\]]+\]:)/m;
+
+/**
+ * Splits one paragraph's raw Markdown text into an ordered list of
+ * { type: 'text'|'bold'|'italic'|'math', text } segments -- mirrors
+ * segmentMixedLatex() in document.js, but for Markdown's emphasis/math
+ * syntax instead of \textbf{}/\textit{}/LaTeX math. Only ever called on
+ * paragraphs that already passed the MARKDOWN_UNSUPPORTED_BLOCK_RE check.
+ */
+function segmentMarkdown(paraText) {
+	const segments = [];
+	let rest = paraText;
+	while (rest.length > 0) {
+		MARKDOWN_MATH_RE.lastIndex = 0;
+		const mathMatch = MARKDOWN_MATH_RE.exec(rest);
+		const boldMatch = MARKDOWN_BOLD_RE.exec(rest);
+		const italicMatch = MARKDOWN_ITALIC_RE.exec(rest);
+
+		// Pick whichever recognized span starts earliest. This also resolves the
+		// bold-vs-italic ambiguity for e.g. "**bold**": MARKDOWN_ITALIC_RE can
+		// match starting one character later (using the second '*' as its own
+		// opening delimiter), but the earlier-starting bold match always wins.
+		const candidates = [
+			mathMatch && { type: 'math', match: mathMatch },
+			boldMatch && { type: 'bold', match: boldMatch },
+			italicMatch && { type: 'italic', match: italicMatch }
+		].filter(Boolean);
+
+		if (candidates.length === 0) {
+			segments.push({ type: 'text', text: rest });
+			break;
+		}
+
+		candidates.sort((a, b) => a.match.index - b.match.index);
+		const { type, match } = candidates[0];
+
+		if (match.index > 0) {
+			segments.push({ type: 'text', text: rest.slice(0, match.index) });
+		}
+		const body = type === 'math' ? (match[1] !== undefined ? match[1] : match[2]) : match[1];
+		segments.push({ type, text: body });
+		rest = rest.slice(match.index + match[0].length);
+	}
+	return segments;
+}
+
+// Flags a top-level node as needing attention without clobbering an earlier
+// flag from the same paragraph (first message wins). Errors/status are
+// tracked at top-level-node granularity throughout this package (see
+// document.js's module doc comment) -- a paragraph with e.g. two
+// unparseable math spans still surfaces as one sync issue, not two.
+function flagUnsupported(topLevelNode, message) {
+	if (topLevelNode.status === 'unsupported' || topLevelNode.status === 'error') return;
+	topLevelNode.status = 'unsupported';
+	topLevelNode.errorPane = 'markdown';
+	topLevelNode.errorMessage = message;
+}
+
+// Builds one PARA Element's children (STRING/BOLD/ITALIC/NEMETH, or a single
+// flagged literal child for unrecognized block-level markdown) from one
+// blank-line-separated chunk of Markdown source.
+async function buildParaFromMarkdown(paraNode, paraSource, table, forward) {
+	if (MARKDOWN_UNSUPPORTED_BLOCK_RE.test(paraSource)) {
+		const child = paraNode.push(tokens.STRING);
+		child.set_value(await forward(paraSource, table));
+		flagUnsupported(
+			paraNode,
+			"This paragraph uses Markdown syntax braille2latex doesn't parse (e.g. a heading, list, table, or code block) — shown as plain translated text rather than being lost."
+		);
+		return;
+	}
+
+	for (const segment of segmentMarkdown(paraSource)) {
+		const text = segment.text;
+		if (segment.type === 'text') {
+			if (text.trim() === '') continue;
+			const child = paraNode.push(tokens.STRING);
+			child.set_value(await forward(text, table));
+		} else if (segment.type === 'bold' || segment.type === 'italic') {
+			const child = paraNode.push(segment.type === 'bold' ? tokens.BOLD : tokens.ITALIC);
+			child.set_value(await forward(text, table));
+		} else if (segment.type === 'math') {
+			const child = paraNode.push(tokens.NEMETH);
+			try {
+				child.set_value(latex_to_nemeth(text));
+			} catch (error) {
+				// Invalid/unbalanced math -- same "surface, don't corrupt" policy as
+				// the rest of this parser: fall back to translating the raw source
+				// (delimiters included) as plain text, flagged for the user.
+				child.token = tokens.STRING;
+				child.set_value(await forward('$' + text + '$', table));
+				flagUnsupported(paraNode, `Couldn't parse this as math (${error.message}) — shown as plain translated text.`);
+			}
+		}
+	}
+}
+
+// Reconstructs the flat, marker-based braille text (the same shape lex()
+// parses -- NEMETHSTART/STOP, BOLD, and ITALIC toggle markers inline) for a
+// PARA/EQUATION node from its already-translated children. The inverse of
+// lex()'s per-word marker scanning, operating on whole children instead.
+function brailleTextOf(node) {
+	switch (node.token) {
+		case tokens.PARA:
+		case tokens.EQUATION:
+			return node.children.map(brailleTextOf).join('');
+		case tokens.NEMETH:
+			return tokenStrings[tokens.NEMETHSTART] + node.get_value() + tokenStrings[tokens.NEMETHSTOP];
+		case tokens.BOLD:
+			return tokenStrings[tokens.BOLD] + node.get_value() + tokenStrings[tokens.BOLD];
+		case tokens.ITALIC:
+			return tokenStrings[tokens.ITALIC] + node.get_value() + tokenStrings[tokens.ITALIC];
+		case tokens.STRING:
+		default:
+			return node.get_value();
+	}
+}
+
+/**
+ * Parses Markdown source into the same Element tree shape lex() builds from
+ * braille, forward-translating recognized prose/bold/italic/math into
+ * braille-ASCII as it goes (braille is still ground truth -- see the
+ * webeditor plan's "Round-trip fidelity" notes for why, and what's
+ * deliberately not built yet). Any construct this parser doesn't recognize
+ * is never dropped: its raw source is forward-translated like ordinary
+ * prose and the enclosing top-level node is flagged via `status`/
+ * `errorPane`/`errorMessage` (same shape DualDocument.errors already reads).
+ *
+ * @param {string} text
+ * @param {{ table?: string, translateForward?: (text: string, table: string) => Promise<string> }} [options]
+ */
+export async function fromMarkdown(text, { table = defaultTable, translateForward: forward } = {}) {
+	if (typeof text !== 'string') throw new Error('Input must be a string');
+	const translateFwd = forward || defaultLiblouisTranslateForward;
+
+	const normalized = text.replace(/(\r\n|\n|\r)/g, '\n');
+	elementIdCounter = 0;
+
+	const parseTree = new Element(tokens.ROOT);
+	// Markdown source commonly has runs of 2+ blank lines between blocks --
+	// split on any such run, unlike lex()'s exact '\n\n' split (braille
+	// paragraphs are always exactly '\n\n'-separated by construction; Markdown
+	// source isn't).
+	const chunks = normalized.split(/\n{2,}/).filter((chunk) => chunk.trim() !== '');
+
+	for (const paraSource of chunks) {
+		const paraNode = parseTree.push(tokens.PARA);
+		paraNode.importedSource = paraSource;
+		await buildParaFromMarkdown(paraNode, paraSource, table, translateFwd);
+		paraNode.check_for_equation();
+	}
+
+	// Braille is ground truth: derive sourceText/brailleRange the same way
+	// lex()/assignTopLevelBrailleRanges() do, from each top-level node's own
+	// (already-translated) content.
+	const brailleParas = parseTree.children.map(brailleTextOf);
+	parseTree.sourceText = brailleParas.join('\n\n');
+	let cursor = 0;
+	parseTree.children.forEach((node, i) => {
+		const para = brailleParas[i];
+		node.brailleRange = { start: cursor, end: cursor + para.length };
+		cursor += para.length + 2; // '\n\n' separator
+	});
 
 	return parseTree;
 }

--- a/src/processFile.js
+++ b/src/processFile.js
@@ -12,7 +12,7 @@ let liblouisReadyPromise = null;
  * Expects `globalThis.LiblouisEasyApiAsync` to already be available — load the
  * vendored easy-api.js (fetched at build time by @brailletools/liblouis-env-web's
  * `liblouis-fetch-web`) via a plain <script> tag in your app's HTML template
- * before calling configure(). braille2latex doesn't fetch or inject that script
+ * before calling configure(). braille-bridge doesn't fetch or inject that script
  * itself: where static assets live and how they're loaded is app-specific (e.g.
  * SvelteKit's app.html), so that's the consuming app's job, not this library's.
  *
@@ -34,7 +34,7 @@ let liblouisReadyPromise = null;
  *
  *   // +page.svelte
  *   import { base } from '$app/paths';
- *   import { configure } from '@brailletools/braille2latex';
+ *   import { configure } from '@brailletools/braille-bridge';
  *   const b = base === '/' ? '' : base;
  *   configure({
  *     liblouisCapiUrl:    `.${b}/liblouis/build-no-tables-utf32.js`,
@@ -47,7 +47,7 @@ export function configure({ liblouisCapiUrl, liblouisEasyApiUrl, liblouisTablesU
 		const EasyApiAsync = globalThis.LiblouisEasyApiAsync;
 		if (!EasyApiAsync) {
 			throw new Error(
-				'[braille2latex] configure() needs `LiblouisEasyApiAsync` to already be available as a ' +
+				'[braille-bridge] configure() needs `LiblouisEasyApiAsync` to already be available as a ' +
 				'global. Load the vendored easy-api.js (see @brailletools/liblouis-env-web) via a <script> ' +
 				'tag before calling configure() — see this package\'s README for a working example.'
 			);
@@ -811,7 +811,7 @@ export function lex(text) {
 
 // Same $...$/$$...$$ math delimiters segmentMixedLatex()/extractMathBody()
 // in document.js already recognize for LaTeX -- Pandoc's default Markdown
-// math extension uses identical syntax, so braille2latex speaks one math
+// math extension uses identical syntax, so braille-bridge speaks one math
 // delimiter dialect across both target formats.
 const MARKDOWN_MATH_RE = /\$\$([\s\S]*?)\$\$|\$([^$\n]*)\$/g;
 
@@ -904,7 +904,7 @@ async function buildParaFromMarkdown(paraNode, paraSource, table, forward) {
 		child.set_value(await forward(paraSource, table));
 		flagUnsupported(
 			paraNode,
-			"This paragraph uses Markdown syntax braille2latex doesn't parse (e.g. a heading, list, table, or code block) — shown as plain translated text rather than being lost."
+			"This paragraph uses Markdown syntax braille-bridge doesn't parse (e.g. a heading, list, table, or code block) — shown as plain translated text rather than being lost."
 		);
 		return;
 	}

--- a/src/processFile.js
+++ b/src/processFile.js
@@ -190,6 +190,59 @@ const tokenStrings = {
 	[tokens.ITALIC]: '_/'
 };
 
+// Single source of truth for marker behavior, shared by lex()'s NEMETH-content char
+// loop and its word-based char loop below, and by computeTopLevelBrailleSpans's
+// SPAN_TYPE_FOR_MARKER further down -- each of those previously kept its own
+// near-duplicate switch-case/table, which is exactly how BOLD/ITALIC drifted out of
+// sync with NEMETHSTART's "close an open STRING first" rule (see applyMarker()'s
+// doc comment) and caused bold/italic content to be silently dropped. NEMETHSTART/
+// NEMETHSTOP are an open/close pair (start always nests one level deeper, stop
+// always closes the nearest NEMETH); BOLD/ITALIC are toggles (close if already the
+// innermost open span, else open one).
+const MARKERS = {
+	[tokenStrings[tokens.NEMETHSTART]]: { kind: 'open', span: tokens.NEMETH },
+	[tokenStrings[tokens.NEMETHSTOP]]: { kind: 'close', span: tokens.NEMETH },
+	[tokenStrings[tokens.BOLD]]: { kind: 'toggle', span: tokens.BOLD },
+	[tokenStrings[tokens.ITALIC]]: { kind: 'toggle', span: tokens.ITALIC }
+};
+
+// Applies one marker's effect starting from `currentToken`, returning the new
+// current node. Any marker first closes an open STRING node -- previously only
+// NEMETHSTART did this ("Close STRING token if we're in one"), so a BOLD/ITALIC
+// marker appearing after any plain word in the same paragraph nested as a CHILD of
+// the already-open STRING instead of a PARA-level sibling. Element.to_latex()/
+// to_markdown()'s STRING case only ever renders `this.value` and never recurses
+// into `.children`, so that nested span was silently discarded rather than
+// rendered -- this symmetric rule is the actual fix, for every marker type,
+// present and future, not just a patch for BOLD/ITALIC specifically.
+function applyMarker(currentToken, marker) {
+	switch (marker.kind) {
+		case 'open':
+			// Always opens a new (possibly nested) span -- close STRING first.
+			if (currentToken.token === tokens.STRING) currentToken = currentToken.parent;
+			return currentToken.push(marker.span);
+		case 'close':
+			// Only closes a matching already-open span; a stray close marker with no
+			// matching open (e.g. "abc_:def" with no preceding "_%") is a no-op --
+			// currentToken can't be STRING here in well-formed input (an 'open'
+			// marker always closes STRING before opening, so by the time its matching
+			// 'close' arrives, currentToken is already the span, not STRING again),
+			// so STRING must NOT be closed for a stray marker that turns out not to
+			// match -- doing so would strand any further text in this word onto the
+			// PARA node's own (never-rendered) .value instead of the still-open STRING.
+			return currentToken.token === marker.span ? currentToken.parent : currentToken;
+		case 'toggle':
+			// Closes if currentToken is already this span (never STRING in that
+			// case, so no STRING-closing needed); otherwise opens a new one, which
+			// -- like 'open' above -- must close STRING first.
+			if (currentToken.token === marker.span) return currentToken.parent;
+			if (currentToken.token === tokens.STRING) currentToken = currentToken.parent;
+			return currentToken.push(marker.span);
+		default:
+			return currentToken;
+	}
+}
+
 class Element {
 	constructor(token, parent = null) {
 		this.id = elementIdCounter++;
@@ -531,13 +584,23 @@ function assignTopLevelBrailleRanges(root, normalizedText) {
 	});
 }
 
-// Maps each of the four structural markers lex() recognizes to the span type it
-// opens — 'nemeth'/'bold'/'italic' spans nest (a NEMETH, BOLD, or ITALIC region
-// can contain any of the others); plain content between/outside them is 'text'.
-const SPAN_TYPE_FOR_MARKER = {
-	[tokenStrings[tokens.BOLD]]: 'bold',
-	[tokenStrings[tokens.ITALIC]]: 'italic'
+// Maps each toggle-style marker (BOLD/ITALIC -- NEMETHSTART/STOP are handled
+// separately below via their own open/close pair, not through this map) to the
+// span type it opens — 'nemeth'/'bold'/'italic' spans nest (a NEMETH, BOLD, or
+// ITALIC region can contain any of the others); plain content between/outside
+// them is 'text'. Derived from the shared MARKERS table above rather than
+// hand-maintained separately -- see MARKERS's doc comment for why that
+// duplication was the root cause of a real bug.
+const SPAN_TYPE_STRING = {
+	[tokens.NEMETH]: 'nemeth',
+	[tokens.BOLD]: 'bold',
+	[tokens.ITALIC]: 'italic'
 };
+const SPAN_TYPE_FOR_MARKER = Object.fromEntries(
+	Object.entries(MARKERS)
+		.filter(([, marker]) => marker.kind === 'toggle')
+		.map(([markerText, marker]) => [markerText, SPAN_TYPE_STRING[marker.span]])
+);
 
 // A lightweight, marker-only scan of one paragraph's raw braille text, computing
 // the top-level (direct-PARA-child) span boundaries a correctly-formed input
@@ -652,6 +715,25 @@ function assignParaChildBrailleRanges(paraNode, paraRawText) {
 	paraNode.childRangesReliable = true;
 }
 
+// Future extension point: heading/list support. Real BANA (Braille Authority of
+// North America) *Braille Formats* conventions distinguish headings and lists by
+// LINE INDENTATION and blank-line context, not by inline character markers like
+// MARKERS above -- e.g. a centered heading is a blank line, then centered text,
+// then a blank line (3+ blank cells each side); cell-5/cell-7 headings are
+// recognized by their fixed indent depth; lists use paragraph-indent/runover-
+// indent pairs ("1-3" notation), with nested levels each adding 2 cells. That's a
+// block-level layout concern, orthogonal to the inline BOLD/ITALIC/NEMETH toggle
+// spans MARKERS models. The natural place to add it: a classification pass run on
+// each paragraph's raw lines *before* the word-based loop below -- measure
+// first-line indent vs. runover-line indent, classify as Paragraph/Heading(level)/
+// ListItem(level) via a small table (additive rows, not new special-cased
+// branches, mirroring how MARKERS keeps inline spans in one place) -- then hand
+// the paragraph's text (indentation stripped) to the existing loop below
+// unchanged for BOLD/ITALIC/NEMETH spans within it. Not yet implemented: new
+// HEADING/LISTITEM Element tokens, to_latex()/to_markdown()/fromMarkdown() cases,
+// and DualDocument sync/error-tracking support for them are real new feature
+// surface, deserving their own scoped plan once house-style indent depths are
+// confirmed against real transcribed files.
 export function lex(text) {
 	if (typeof text !== 'string') throw new Error('Input must be a string');
 
@@ -664,6 +746,15 @@ export function lex(text) {
 	paragraphs.forEach(para => {
 		const paraNode = parseTree.push(tokens.PARA);
 		let currentToken = paraNode;
+		// Deferred inter-word/inter-line separator: rather than appending a trailing
+		// space immediately (which, for a span that closes back to PARA, would land
+		// INSIDE that span's closing marker -- e.g. "\textbf{HELLO }world" instead of
+		// the correct "\textbf{HELLO} world"), the space is flushed at the start of
+		// whatever comes next, onto whichever node actually receives it. See the
+		// flush site below for the one deliberate case (two marker spans back-to-back
+		// with nothing but a separator between them) where there's no live node to
+		// receive it, and PARA's last child is used as a fallback instead.
+		let pendingSpace = false;
 
 		const lines = para.split('\n');
 		lines.forEach((line, lineIndex) => {
@@ -671,28 +762,13 @@ export function lex(text) {
 			if (currentToken.token === tokens.NEMETH) {
 				for (let i = 0; i < line.length; i++) {
 					const firsttwo = line.substring(i, i + 2);
-					switch (firsttwo) {
-						case tokenStrings.NEMETHSTART:
-							currentToken = currentToken.push(tokens.NEMETH);
-							i++;
-							continue;
-						case tokenStrings.NEMETHSTOP:
-							if (currentToken.token === tokens.NEMETH) currentToken = currentToken.parent;
-							i++;
-							continue;
-						case tokenStrings.BOLD:
-							if (currentToken.token === tokens.BOLD) currentToken = currentToken.parent;
-							else currentToken = currentToken.push(tokens.BOLD);
-							i++;
-							continue;
-						case tokenStrings.ITALIC:
-							if (currentToken.token === tokens.ITALIC) currentToken = currentToken.parent;
-							else currentToken = currentToken.push(tokens.ITALIC);
-							i++;
-							continue;
-						default:
-							currentToken.add_character(line[i]);
+					const marker = MARKERS[firsttwo];
+					if (marker) {
+						currentToken = applyMarker(currentToken, marker);
+						i++;
+						continue;
 					}
+					currentToken.add_character(line[i]);
 				}
 			} else {
 				// For non-NEMETH content, use word-based processing
@@ -700,92 +776,61 @@ export function lex(text) {
 				words.forEach((word) => {
 					if (!word) return;
 
-					let needsStringToken = false;
 					if (currentToken.token === tokens.PARA) {
 						const firsttwo = word.substring(0, 2);
-						if (
-							firsttwo !== tokenStrings.NEMETHSTART &&
-							firsttwo !== tokenStrings.NEMETHSTOP &&
-							firsttwo !== tokenStrings.BOLD &&
-							firsttwo !== tokenStrings.ITALIC
-						) {
-							needsStringToken = true;
-							// Only create a new STRING token if we're not already in one
-							if (currentToken.token !== tokens.STRING) {
-								currentToken = currentToken.push(tokens.STRING);
-							}
+						// Only create a new STRING token if this word isn't itself a
+						// marker, and we're not already in one
+						if (!MARKERS[firsttwo] && currentToken.token !== tokens.STRING) {
+							currentToken = currentToken.push(tokens.STRING);
 						}
+					}
+
+					// Flush the pending separator now, onto whatever node is about to
+					// receive this word's content: the still-open STRING/BOLD/ITALIC/
+					// NEMETH from a continuing run (e.g. a single-character word mid-
+					// bold-run, or a NEMETH block whose content is line-wrapped across
+					// several "words"), or the STRING just pushed above.
+					if (pendingSpace) {
+						if (
+							currentToken.token === tokens.STRING ||
+							currentToken.token === tokens.BOLD ||
+							currentToken.token === tokens.ITALIC ||
+							currentToken.token === tokens.NEMETH
+						) {
+							currentToken.add_character(' ');
+						} else if (currentToken.token === tokens.PARA && currentToken.children.length > 0) {
+							currentToken.children[currentToken.children.length - 1].add_character(' ');
+						}
+						pendingSpace = false;
 					}
 
 					for (let i = 0; i < word.length; i++) {
 						const firsttwo = word.substring(i, i + 2);
-						switch (firsttwo) {
-							case tokenStrings.NEMETHSTART:
-							// Close STRING token if we're in one
-							if (currentToken.token === tokens.STRING) {
-								currentToken = currentToken.parent;
-							}
-								currentToken = currentToken.push(tokens.NEMETH);
-								i++;
-								continue;
-							case tokenStrings.NEMETHSTOP:
-								// A NEMETH block opened mid-word/mid-line (via NEMETHSTART above) closes here 
-								if (currentToken.token === tokens.NEMETH) currentToken = currentToken.parent;
-								i++;
-								continue;
-							case tokenStrings.BOLD:
-								if (currentToken.token === tokens.BOLD) currentToken = currentToken.parent;
-								else currentToken = currentToken.push(tokens.BOLD);
-								i++;
-								continue;
-							case tokenStrings.ITALIC:
-								if (currentToken.token === tokens.ITALIC) currentToken = currentToken.parent;
-								else currentToken = currentToken.push(tokens.ITALIC);
-								i++;
-								continue;
-							default:
-								currentToken.add_character(word[i]);
+						const marker = MARKERS[firsttwo];
+						if (marker) {
+							currentToken = applyMarker(currentToken, marker);
+							i++;
+							continue;
 						}
+						currentToken.add_character(word[i]);
 					}
 
-					if (needsStringToken && currentToken.token === tokens.STRING) {
-						if (currentToken.get_value().endsWith(' ')) {
-							currentToken.value = currentToken.value.slice(0, -1);
-						}
-						// Don't close the STRING token yet - keep it open for consecutive words
-						// currentToken = currentToken.parent;
-					}
-
-					if (
-						currentToken.token === tokens.STRING ||
-						currentToken.token === tokens.NEMETH ||
-						currentToken.token === tokens.BOLD ||
-						currentToken.token === tokens.ITALIC
-					) {
-						currentToken.add_character(' ');
-					}
+					pendingSpace = true;
 				});
-
-				if (currentToken.get_value && currentToken.get_value().endsWith(' ')) {
-					currentToken.value = currentToken.value.slice(0, -1);
-				}
 			}
-			
+
 			// A single '\n' inside a paragraph is a line wrap, not a paragraph break
 			// (that's '\n\n', split out above) -- it still stands for whitespace between
 			// the last word of this line and the first word of the next, or the last
 			// word of one line and the last word of the next line fuse together with
 			// no separator at all. NEMETH content preserves the literal newline instead
-			// (verbatim rendering of Nemeth math); everything else gets a space.
+			// (verbatim rendering of Nemeth math); everything else defers to the same
+			// pendingSpace flush the word loop above uses.
 			if (lineIndex < lines.length - 1) {
 				if (currentToken.token === tokens.NEMETH) {
 					currentToken.add_character('\n');
-				} else if (
-					currentToken.token === tokens.STRING ||
-					currentToken.token === tokens.BOLD ||
-					currentToken.token === tokens.ITALIC
-				) {
-					currentToken.add_character(' ');
+				} else {
+					pendingSpace = true;
 				}
 			}
 		});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,112 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, unlinkSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.join(__dirname, '../bin/braille2latex.js');
+
+/** Runs the CLI against a fresh fixture file, cleaning it up afterward. */
+function withFixture(name, content, run) {
+	const fixture = path.join(__dirname, name);
+	writeFileSync(fixture, content);
+	try {
+		return run(fixture);
+	} finally {
+		unlinkSync(fixture);
+	}
+}
+
+test('CLI converts a .brf file to LaTeX (default format) without crashing', () => {
+	withFixture('fixture.brf', 'HELLO WORLD\n', (fixture) => {
+		const output = execFileSync('node', [cliPath, fixture, '--braille-only'], { encoding: 'utf8' });
+		assert.notEqual(output.trim(), '');
+	});
+});
+
+test('CLI --format markdown converts a .brf file to Markdown instead of LaTeX', () => {
+	withFixture('fixture-md.brf', '_.HELLO_. WORLD\n', (fixture) => {
+		const output = execFileSync('node', [cliPath, fixture, '--braille-only', '--format', 'markdown'], {
+			encoding: 'utf8'
+		});
+		assert.notEqual(output.trim(), '');
+		assert.doesNotMatch(output, /\\textbf/, 'markdown output must not contain LaTeX bold markup');
+		assert.match(output, /\*\*/, 'expected a Markdown bold span');
+	});
+});
+
+test('CLI --format rst routes through Pandoc (a non-hand-rolled format)', () => {
+	withFixture('fixture-rst.brf', '_.HELLO_. WORLD\n', (fixture) => {
+		const output = execFileSync('node', [cliPath, fixture, '--braille-only', '--format', 'rst'], {
+			encoding: 'utf8'
+		});
+		assert.notEqual(output.trim(), '');
+		assert.doesNotMatch(output, /\\textbf/, 'must not be LaTeX');
+		assert.match(output, /\*\*/, 'reStructuredText also uses ** for bold');
+	});
+});
+
+test('CLI --format html --full-doc maps to Pandoc\'s standalone:true (full <html> wrapper)', () => {
+	withFixture('fixture-html.brf', 'HELLO\n', (fixture) => {
+		const fragment = execFileSync('node', [cliPath, fixture, '--braille-only', '--format', 'html'], {
+			encoding: 'utf8'
+		});
+		const standalone = execFileSync(
+			'node',
+			[cliPath, fixture, '--braille-only', '--format', 'html', '--full-doc'],
+			{ encoding: 'utf8' }
+		);
+		assert.doesNotMatch(fragment, /<html/i);
+		assert.match(standalone, /<html/i);
+	});
+});
+
+test('CLI rejects a binary --format (e.g. docx) without -o', () => {
+	withFixture('fixture-docx-noout.brf', 'HELLO\n', (fixture) => {
+		try {
+			execFileSync('node', [cliPath, fixture, '--braille-only', '--format', 'docx'], {
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'pipe']
+			});
+			assert.fail('expected the CLI to exit non-zero');
+		} catch (error) {
+			assert.match(error.stderr.toString(), /produces a binary document/);
+		}
+	});
+});
+
+test('CLI --format docx -o FILE writes a real .docx (zip) file', () => {
+	withFixture('fixture-docx.brf', '_.HELLO_. WORLD\n', (fixture) => {
+		const outPath = path.join(__dirname, 'fixture-out.docx');
+		try {
+			execFileSync('node', [cliPath, fixture, '--braille-only', '--format', 'docx', '-o', outPath], {
+				encoding: 'utf8'
+			});
+			const bytes = readFileSync(outPath);
+			assert.ok(bytes.length > 0);
+			assert.equal(bytes.slice(0, 2).toString(), 'PK', 'a .docx file is a zip archive (PK header)');
+		} finally {
+			try {
+				unlinkSync(outPath);
+			} catch {
+				// already absent
+			}
+		}
+	});
+});
+
+test('CLI rejects an unknown Pandoc --format cleanly (no raw stack trace)', () => {
+	withFixture('fixture-badformat.brf', 'HELLO\n', (fixture) => {
+		try {
+			execFileSync('node', [cliPath, fixture, '--braille-only', '--format', 'not-a-real-format'], {
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'pipe']
+			});
+			assert.fail('expected the CLI to exit non-zero');
+		} catch (error) {
+			assert.match(error.stderr.toString(), /--format not-a-real-format failed/);
+		}
+	});
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const cliPath = path.join(__dirname, '../bin/braille2latex.js');
+const cliPath = path.join(__dirname, '../bin/braille-bridge.js');
 
 /** Runs the CLI against a fresh fixture file, cleaning it up afterward. */
 function withFixture(name, content, run) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -187,12 +187,14 @@ test('applyLatexEdit deletes a whole Nemeth segment atomically, leaving no orpha
 });
 
 test('applyLatexEdit falls back to whole-node regeneration when childRangesReliable is false, without corrupting anything', async () => {
-	// 'abc_.bold_.' hits a separate, pre-existing lexer quirk (a BOLD marker
-	// landing directly against a word with no space nests it under the STRING
-	// node instead of as a PARA sibling), which the marker-only scanner can't
-	// predict — see the equivalent lex()-level test in smoke.test.js. This proves
-	// the *edit* path degrades safely too, not just the scan/flag itself.
-	const doc = await makeDoc('abc_.bold_.');
+	// 'abc_:def' has a stray NEMETHSTOP with no matching NEMETHSTART. lex()
+	// correctly treats this as a no-op (the text stays one continuous STRING run
+	// -- see applyMarker()'s 'close' case), but the marker-only scanner in
+	// computeTopLevelBrailleSpans can't tell a stray close marker from a real one
+	// until it's too late, so it splits its guess into two 'text' spans where the
+	// real tree only has one STRING child — a genuine, expected mismatch. This
+	// proves the *edit* path degrades safely too, not just the scan/flag itself.
+	const doc = await makeDoc('abc_:def');
 	const para = doc.topLevelNodes[0];
 	assert.equal(para.token, 'PARA');
 	assert.equal(para.childRangesReliable, false, 'sanity check: this fixture must hit the fallback path');

--- a/test/fixtures/mixed-formatting.brf
+++ b/test/fixtures/mixed-formatting.brf
@@ -1,0 +1,9 @@
+,? quiz cov}s _.*apt} "o_. & _.*apt} two_. ( ! textbook4
+
+,solve = ;x3 _%X+2 .K #5_:
+
+,! t}m _/d}ivative_/ describes ! rate ( *ange1 & ! t}m _/9tegral_/ describes a3umula;n4
+
+,a well-"kn id5t;y is _%A^2"+B^2 .K C^2_: : is ! ,py?agor1n !orem4
+
+,rememb} to %{ yr "w & label ea* _.answ}_. cle>ly4

--- a/test/lex-formatting.test.js
+++ b/test/lex-formatting.test.js
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+
+import { lex } from '../src/index.js';
+
+// Real back-translation via lou_translate (not the identity stand-in used
+// elsewhere) -- these tests are specifically probing realistic documents
+// where BOLD/ITALIC/NEMETH markers appear *after* plain text within the same
+// paragraph, a pattern the identity-translate unit tests don't exercise
+// clearly since they mostly use single-word fixtures. Skips cleanly if
+// lou_translate isn't installed in this environment.
+let louTranslatePath = null;
+try {
+	const { resolveLouTranslate } = await import('@brailletools/liblouis-env');
+	louTranslatePath = resolveLouTranslate();
+} catch {
+	// @brailletools/liblouis-env not resolvable in this environment; tests
+	// below fall back to an identity translate (still exercises the *tree
+	// structure*, just not real contraction behavior).
+}
+
+async function translate(unicodeBraille, table) {
+	if (!louTranslatePath) return unicodeBraille;
+	// Strip only a trailing newline, not all trailing whitespace -- a trailing
+	// space can be meaningful content (see bin/braille-bridge.js's translate()
+	// for the full explanation).
+	return execFileSync(louTranslatePath, ['--backward', table], {
+		input: unicodeBraille,
+		encoding: 'utf8'
+	}).replace(/\r?\n+$/, '');
+}
+
+test('a BOLD span following plain text in the same paragraph is a PARA-level sibling, not nested under STRING', async () => {
+	// "hello _.WORLD_. there" -- WORLD is bold, and comes after "hello " has
+	// already opened a STRING node. Before the fix, the BOLD marker nested as a
+	// CHILD of that STRING node (to_latex()'s STRING case never recurses into
+	// .children, so the whole word vanished). applyMarker() now closes STRING
+	// before opening BOLD, so BOLD is a sibling instead.
+	const tree = lex('hello _.WORLD_. there');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 3, 'STRING("hello "), BOLD("world"), STRING(" there")');
+	assert.equal(para.children[0].token, 'STRING');
+	assert.equal(para.children[1].token, 'BOLD');
+	assert.equal(para.children[2].token, 'STRING');
+
+	const latex = await tree.to_latex('en-ueb-g2.ctb', translate);
+	assert.match(latex, /\\textbf\{[^}]*\}/, 'bold content must survive, wrapped in \\textbf{}');
+	assert.match(latex, /hello.*\\textbf\{[^}]*\}.*there/s, 'plain text on both sides must survive too');
+});
+
+test('an ITALIC span following plain text in the same paragraph is a PARA-level sibling, not nested under STRING', async () => {
+	const tree = lex('hello _/WORLD_/ there');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 3);
+	assert.equal(para.children[1].token, 'ITALIC');
+
+	const latex = await tree.to_latex('en-ueb-g2.ctb', translate);
+	assert.match(latex, /\\textit\{[^}]*\}/, 'italic content must survive, wrapped in \\textit{}');
+});
+
+test('a BOLD span at the very end of a paragraph (nothing after it) survives', async () => {
+	const tree = lex('hello _.WORLD_.');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 2, 'STRING("hello "), BOLD("world")');
+
+	const latex = await tree.to_latex('en-ueb-g2.ctb', translate);
+	assert.match(latex, /\\textbf\{[^}]*\}/, 'trailing bold content must survive');
+});
+
+test('a space appears between a leading BOLD/ITALIC span and the text that follows it', async () => {
+	// "_.HELLO_. world" -- BOLD is first in the paragraph, so it was already a
+	// correct PARA-level sibling even before the fix -- but the space between
+	// it and the next word used to be silently lost (the trailing-space check
+	// only fired for currentToken types STRING/NEMETH/BOLD/ITALIC, and
+	// immediately after a span closes, currentToken is back to PARA).
+	const tree = lex('_.HELLO_. world');
+	const latex = await tree.to_latex('en-ueb-g2.ctb', translate);
+	assert.match(latex, /\\textbf\{[^}]*\} \S/, 'a space must separate the bold span from "world"');
+});
+
+test('two marker spans back-to-back, separated only by whitespace in the source, both survive with a separator', async () => {
+	const tree = lex('_.BOLD_. _/ITALIC_/');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 2);
+	assert.equal(para.children[0].token, 'BOLD');
+	assert.equal(para.children[1].token, 'ITALIC');
+
+	const latex = await tree.to_latex('en-ueb-g2.ctb', translate);
+	assert.match(latex, /\\textbf\{[^}]*\}/);
+	assert.match(latex, /\\textit\{[^}]*\}/);
+});
+
+test('ITALIC nested inside BOLD is preserved as a child span, not dropped', async () => {
+	const tree = lex('_.bold _/and italic_/ together_.');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 1);
+	assert.equal(para.children[0].token, 'BOLD');
+	const nestedItalic = para.children[0].children.find((c) => c.token === 'ITALIC');
+	assert.ok(nestedItalic, 'ITALIC must appear as a child of the enclosing BOLD span');
+
+	const latex = await tree.to_latex('en-ueb-g2.ctb', translate);
+	assert.match(latex, /\\textbf\{[^}]*\\textit\{[^}]*\}[^}]*\}/, 'ITALIC must be nested inside \\textbf{}');
+});
+
+test('Reference (currently passing): plain, unmarked multi-word paragraphs are unaffected', async () => {
+	// Included so the rewrite's regression risk is visible against a known-good
+	// baseline of ordinary text, not just the previously-broken cases above.
+	const tree = lex('hello there friend');
+	const para = tree.children[0];
+	assert.equal(para.children.length, 1);
+	assert.equal(para.children[0].token, 'STRING');
+});

--- a/test/markdown.test.js
+++ b/test/markdown.test.js
@@ -1,0 +1,183 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DualDocument, ascii2Braille } from '../src/index.js';
+
+// Same identity stand-ins as document.test.js — these exercise the sync/parsing
+// mechanics, not real braille orthography. translate() echoes unicode braille
+// back unchanged (not real back-translation), so rendered LaTeX/Markdown prose
+// contains unicode-braille glyphs, not the original print text — assertions
+// below account for that (see document.test.js's comment on identityTranslate).
+const identityTranslate = async (unicodeBraille) => unicodeBraille;
+const identityTranslateForward = async (text) => text;
+
+function makeDoc(text) {
+	return DualDocument.fromBraille(text, {
+		translate: identityTranslate,
+		translateForward: identityTranslateForward
+	});
+}
+
+function makeMarkdownDoc(text) {
+	return DualDocument.fromMarkdown(text, {
+		translate: identityTranslate,
+		translateForward: identityTranslateForward
+	});
+}
+
+test('renderMarkdown() renders a plain paragraph and is not auto-updated by applyBrailleEdit', async () => {
+	const doc = await makeDoc('HELLO WORLD');
+	assert.equal(doc.markdownText, '', 'markdown must not be eagerly rendered by fromBraille()');
+
+	const first = await doc.renderMarkdown();
+	assert.ok(first.includes(ascii2Braille('HELLO')));
+
+	// Editing braille must not silently re-render markdown -- it's lazy, only
+	// LaTeX is kept eagerly in sync (see the module's "Round-trip fidelity"
+	// design notes).
+	await doc.applyBrailleEdit('HELLO WORLD MORE', 'HELLO WORLD MORE'.length);
+	assert.equal(doc.markdownText, first, 'markdown must stay stale until renderMarkdown() is called again');
+
+	const second = await doc.renderMarkdown();
+	assert.ok(second.includes(ascii2Braille('MORE')), 'a fresh renderMarkdown() call must reflect the latest braille');
+});
+
+test('to_markdown() renders BOLD as ** and ITALIC as * markers', async () => {
+	// Marker-word-then-plain-word order (matching document.test.js's proven
+	// '_.CAN_. DOG' fixture) keeps BOLD/ITALIC as the PARA's own direct child
+	// rather than nesting under a still-open STRING sibling — a separate,
+	// pre-existing lexer characteristic unrelated to Markdown rendering, not
+	// something this test is meant to exercise.
+	const boldDoc = await makeDoc('_.CAN_. DOG');
+	const boldMd = await boldDoc.renderMarkdown();
+	assert.match(boldMd, /\*\*[^*]+\*\*/, 'expected a **...** bold span');
+
+	const italicDoc = await makeDoc('_/RUN_/ FAST');
+	const italicMd = await italicDoc.renderMarkdown();
+	assert.match(italicMd, /(?<!\*)\*[^*]+\*(?!\*)/, 'expected a *...* italic span');
+});
+
+test('to_markdown() renders NEMETH as $...$ inline math, same delimiters as LaTeX', async () => {
+	const doc = await makeDoc('C\n_%ax = b_:');
+	const md = await doc.renderMarkdown();
+	assert.match(md, /\$[^$]+\$/);
+});
+
+test('fromMarkdown() parses bold/italic/math into distinct node types', async () => {
+	const doc = await makeMarkdownDoc('plain **bold** and *italic* and $x+1$ end');
+	assert.equal(doc.errors.length, 0);
+	const [para] = doc.topLevelNodes;
+	assert.equal(para.token, 'PARA');
+	const tokenTypes = para.children.map((c) => c.token);
+	assert.ok(tokenTypes.includes('BOLD'));
+	assert.ok(tokenTypes.includes('ITALIC'));
+	assert.ok(tokenTypes.includes('NEMETH'));
+	assert.match(doc.brailleText, /_\.[^_]*_\./, 'bold should be wrapped in braille BOLD markers');
+	assert.match(doc.brailleText, /_%[^_]*_:/, 'math should be wrapped in braille NEMETH markers');
+});
+
+test('fromMarkdown() promotes a paragraph that is only math to an EQUATION node', async () => {
+	const doc = await makeMarkdownDoc('$x+1$');
+	assert.equal(doc.topLevelNodes.length, 1);
+	assert.equal(doc.topLevelNodes[0].token, 'EQUATION');
+});
+
+test('fromMarkdown() on a plain paragraph eagerly populates latexText (fromBraille()-equivalent contract)', async () => {
+	const doc = await makeMarkdownDoc('plain text');
+	assert.notEqual(doc.latexText, '', 'fromMarkdown() must eagerly render LaTeX once, like fromBraille() does');
+});
+
+test('fromMarkdown() never drops an unrecognized block-level construct (e.g. a heading) — translates it literally and flags it', async () => {
+	const doc = await makeMarkdownDoc('# A Heading\n\nplain text');
+	assert.equal(doc.topLevelNodes.length, 2);
+	assert.equal(doc.errors.length, 1, 'exactly the heading paragraph should be flagged');
+	assert.equal(doc.errors[0].pane, 'markdown');
+	assert.match(doc.brailleText, /Heading/, 'heading text must survive translation, not be stripped (identity forward here)');
+	assert.match(doc.brailleText, /plain text$/, 'the second, ordinary paragraph must parse normally');
+});
+
+test('fromMarkdown() falls back to literal translation, flagged, when math fails to parse', async () => {
+	const doc = await makeMarkdownDoc('before $\\frac{1}{2$ after'); // unbalanced brace
+	assert.equal(doc.errors.length, 1);
+	assert.equal(doc.errors[0].pane, 'markdown');
+	assert.doesNotMatch(doc.brailleText, /_%/, 'invalid math must not produce a dangling Nemeth marker');
+});
+
+test('fromMarkdown() retains each top-level node\'s original source slice (round-trip-fidelity groundwork)', async () => {
+	const doc = await makeMarkdownDoc('first paragraph\n\nsecond paragraph');
+	assert.equal(doc.topLevelNodes[0].importedSource, 'first paragraph');
+	assert.equal(doc.topLevelNodes[1].importedSource, 'second paragraph');
+});
+
+test('applyMarkdownEdit only re-derives the touched paragraph, leaves the sibling node untouched', async () => {
+	const doc = await makeDoc('HELLO\n\nWORLD');
+	await doc.renderMarkdown();
+	const secondNodeBefore = doc.topLevelNodes[1];
+
+	const oldMd = doc.markdownText;
+	const helloGlyphs = ascii2Braille('HELLO');
+	const insertAt = oldMd.indexOf(helloGlyphs) + helloGlyphs.length;
+	const newMd = oldMd.slice(0, insertAt) + ' MORE' + oldMd.slice(insertAt);
+	const result = await doc.applyMarkdownEdit(newMd, insertAt + 5);
+
+	assert.equal(result.nodeError, null);
+	assert.equal(doc.topLevelNodes.length, 2);
+	assert.equal(doc.topLevelNodes[1], secondNodeBefore, 'sibling node identity preserved (not re-derived)');
+	assert.equal(doc.errors.length, 0);
+});
+
+test('applyMarkdownEdit on an equation node round-trips through latex_to_nemeth and leaves siblings untouched', async () => {
+	const doc = await makeDoc('HELLO\n\n_%3+4_:');
+	await doc.renderMarkdown();
+	assert.equal(doc.topLevelNodes[1].token, 'EQUATION');
+	const firstNodeBefore = doc.topLevelNodes[0];
+
+	const oldMd = doc.markdownText;
+	const newMd = oldMd.replace('3+4', '5+6');
+	const result = await doc.applyMarkdownEdit(newMd, newMd.indexOf('5+6') + 3);
+
+	assert.equal(result.nodeError, null);
+	assert.match(result.brailleText, /5/);
+	assert.match(result.brailleText, /6/);
+	assert.equal(doc.topLevelNodes[0], firstNodeBefore, 'sibling paragraph untouched by an equation edit');
+	assert.equal(doc.errors.length, 0);
+});
+
+test('applyMarkdownEdit surfaces a parse error without corrupting the braille pane', async () => {
+	const doc = await makeDoc('_%3+4_:');
+	await doc.renderMarkdown();
+	const oldBraille = doc.brailleText;
+	const oldMd = doc.markdownText;
+	const broken = oldMd.replace('$3+4$', '$\\frac{1}{2$'); // unbalanced brace
+
+	const result = await doc.applyMarkdownEdit(broken, broken.length);
+
+	assert.notEqual(result.nodeError, null);
+	assert.equal(result.brailleText, oldBraille, 'braille pane must be left untouched on failure');
+	assert.equal(doc.errors.length, 1);
+	assert.equal(doc.errors[0].pane, 'markdown');
+});
+
+test('applyMarkdownEdit spanning multiple top-level nodes is flagged, not silently corrupted', async () => {
+	const doc = await makeDoc('HELLO\n\nWORLD');
+	await doc.renderMarkdown();
+	const oldMd = doc.markdownText;
+	const oldBraille = doc.brailleText;
+	const spanStart = doc.topLevelNodes[0].markdownRange.start + 1;
+	const spanEnd = doc.topLevelNodes[1].markdownRange.start + 1;
+	const spanningEdit = oldMd.slice(0, spanStart) + 'XX' + oldMd.slice(spanEnd);
+
+	const result = await doc.applyMarkdownEdit(spanningEdit, spanStart + 2);
+
+	assert.notEqual(result.nodeError, null);
+	assert.equal(result.brailleText, oldBraille, 'braille pane left untouched when an edit spans multiple nodes');
+	assert.ok(doc.errors.length >= 1);
+});
+
+test('mapCursor works across brailleRange/markdownRange, same as it does for latexRange', async () => {
+	const doc = await makeDoc('HELLO\n\nWORLD');
+	await doc.renderMarkdown();
+	const secondNode = doc.topLevelNodes[1];
+	const mapped = doc.mapCursor('brailleRange', 'markdownRange', secondNode.brailleRange.start + 1);
+	assert.ok(mapped >= secondNode.markdownRange.start && mapped <= secondNode.markdownRange.end);
+});

--- a/test/pandoc.test.js
+++ b/test/pandoc.test.js
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { convertText, convertToBinaryFormat, convertFromBinaryFormat } from '../src/index.js';
+
+// These exercise the real pandoc-wasm Node entry point (no mocking) -- it
+// reads its wasm binary from local disk (see src/pandoc.js's doc comment),
+// so this has no network dependency and is fast/reliable in CI.
+
+test('convertText() converts LaTeX to Markdown', async () => {
+	const md = await convertText('\\textbf{Hi} $x+1$', 'latex', 'markdown');
+	assert.equal(typeof md, 'string');
+	assert.match(md, /\*\*Hi\*\*/, 'expected Markdown bold markup');
+	assert.match(md, /\$x\s*\+\s*1\$/, 'expected math delimiters preserved');
+});
+
+test('convertText() accepts extraOptions (e.g. standalone) merged into Pandoc options', async () => {
+	const fragment = await convertText('# Hi', 'markdown', 'html');
+	const standalone = await convertText('# Hi', 'markdown', 'html', { standalone: true });
+	assert.doesNotMatch(fragment, /<html/i, 'fragment output should not include a document wrapper');
+	assert.match(standalone, /<html/i, 'standalone:true should wrap output in a full document');
+});
+
+test('convertText() surfaces a Pandoc error for an unknown writer', async () => {
+	await assert.rejects(() => convertText('hi', 'markdown', 'not-a-real-format'), /Unknown output format/);
+});
+
+test('convertToBinaryFormat()/convertFromBinaryFormat() round-trip Markdown through a real .docx file', async () => {
+	const docxBlob = await convertToBinaryFormat('**Hello** World $x+1$', 'markdown', 'docx');
+	assert.ok(docxBlob instanceof Blob);
+	assert.ok(docxBlob.size > 0);
+
+	const buf = Buffer.from(await docxBlob.arrayBuffer());
+	assert.equal(buf.slice(0, 2).toString(), 'PK', 'a .docx file is a zip archive (PK header)');
+
+	const markdownBack = await convertFromBinaryFormat(docxBlob, 'docx', 'markdown');
+	assert.match(markdownBack, /\*\*Hello\*\*/);
+	assert.match(markdownBack, /\$x\s*\+\s*1\$/);
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,14 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { writeFileSync, unlinkSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
 
-import { lex, parseWithTranslator, ascii2Braille, braille2Ascii, nemeth_to_latex, latex_to_nemeth } from '../src/index.js';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const cliPath = path.join(__dirname, '../bin/braille2latex.js');
+import { lex, ascii2Braille, braille2Ascii, nemeth_to_latex, latex_to_nemeth } from '../src/index.js';
 
 test('ascii2Braille/braille2Ascii round-trip plain text', () => {
 	const unicode = ascii2Braille('HELLO');
@@ -169,24 +162,13 @@ test('lex() falls back to childRangesReliable = false when the marker-only scan 
 	assert.equal(para.children[0].brailleRange, null, 'brailleRange must be left unset, not a guessed value');
 });
 
-test('parseWithTranslator() converts plain text to LaTeX without needing liblouis installed', async () => {
-	// Identity translator stands in for a real back-translation backend (liblouis WASM or
-	// lou_translate) — this is the same shape of call the CLI makes, and is the smoke test
-	// that would have caught the previous bug where importing this module at all required
-	// the `liblouis` peer dependency to be installed, even for callers who never use it.
+test('lex()/to_latex() converts plain text to LaTeX without needing liblouis installed', async () => {
+	// Identity translator stands in for a real back-translation backend (liblouis
+	// WASM) — this is the smoke test that would have caught the previous bug
+	// where importing this module at all required the `liblouis` peer dependency
+	// to be installed, even for callers who never use it.
 	const identityTranslate = async (unicodeBraille) => unicodeBraille;
-	const latex = await parseWithTranslator('HELLO WORLD', 'en-ueb-g2.ctb', identityTranslate);
+	const latex = await lex('HELLO WORLD').to_latex('en-ueb-g2.ctb', identityTranslate);
 	assert.equal(typeof latex, 'string');
 	assert.notEqual(latex.trim(), '');
-});
-
-test('CLI converts a .brf file to output without crashing', () => {
-	const fixture = path.join(__dirname, 'fixture.brf');
-	writeFileSync(fixture, 'HELLO WORLD\n');
-	try {
-		const output = execFileSync('node', [cliPath, fixture, '--braille-only'], { encoding: 'utf8' });
-		assert.notEqual(output.trim(), '');
-	} finally {
-		unlinkSync(fixture);
-	}
 });


### PR DESCRIPTION
## Summary
- Add Markdown output/import (`fromMarkdown()`, `DualDocument.fromMarkdown()`) and Pandoc-based conversion to any Pandoc-supported format (`src/pandoc.js`, generalized CLI `--format`), enabling Word/OMML math support via Pandoc's native handling.
- Rename the package/repo from `braille2latex` to `braille-bridge` (npm name, CLI binary, README, all internal references) to reflect that it's grown into a bidirectional braille⟷LaTeX/Markdown sync engine, not just a one-way LaTeX converter.
- Fix a real content-loss bug in `lex()`: a BOLD/ITALIC span appearing anywhere after plain text in the same paragraph was silently nested inside the already-open STRING node instead of as a sibling, so `to_latex()`/`to_markdown()` (which never recurse into STRING's children) dropped it entirely. Replaced the duplicated per-marker switch-cases with one shared, symmetric marker table (`MARKERS`/`applyMarker()`), which also fixes a related missing-space bug and the `childRangesReliable`-driven full-paragraph regeneration that was causing unrelated live-sync edits to drift.

## Test plan
- [x] `npm test` — 61/61 passing (includes new `test/lex-formatting.test.js` and a realistic multi-paragraph `test/fixtures/mixed-formatting.brf` stress fixture)
- [x] `npm run lint`
- [x] Manual CLI run on `test/fixtures/mixed-formatting.brf` for both `--format latex` and `--format markdown` — all bold/italic/math spans survive with correct spacing
- [x] Downstream `webeditor` `test:sync`/`test:unit` re-verified against this branch via the `file:` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)